### PR TITLE
Switch to Web Speech API for phrase playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# greek-phrases
+# Greek Travel Phrases
+
+A static, mobile-friendly website listing common Greek phrases helpful for travelers. Tap a phrase to hear the pronunciation through the browser's text-to-speech engine.
+
+## Features
+
+- Responsive layout that works well on phones and tablets
+- Phrases are configured in [`phrases.json`](phrases.json) and loaded dynamically
+- Pronunciation playback uses the Web Speech API, so no audio files are required
+- Optional transliteration field to help with practicing pronunciation
+
+## Editing the phrase list
+
+Each entry in `phrases.json` accepts the following keys:
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `greek` | ✅ | The Greek phrase shown in the list. |
+| `english` | ✅ | Translation or description of the phrase. |
+| `pronunciation` | ➖ | Optional transliteration displayed under the Greek text. |
+| `speech` | ➖ | Override text spoken by text-to-speech. Defaults to the `greek` text. |
+| `lang` | ➖ | BCP 47 language code passed to the speech engine. Defaults to `el-GR`. |
+| `rate` | ➖ | Speech rate (1 is the browser default). |
+
+Example entry:
+
+```json
+{
+  "greek": "Πού είναι το ξενοδοχείο;",
+  "english": "Where is the hotel?",
+  "pronunciation": "Pou íne to xenodohío?",
+  "lang": "el-GR",
+  "rate": 0.9
+}
+```
+
+## Local preview
+
+Open `index.html` in a browser. For full text-to-speech support you may need to serve the files over `http://` or `https://` depending on your browser's security settings.
+
+## Deployment
+
+This site is static and can be hosted on GitHub Pages:
+
+1. Push the repository to GitHub.
+2. In the repository settings, enable GitHub Pages and select the `main` branch (or the branch that should be published).
+3. Wait for the deployment to finish and access the published URL provided by GitHub.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Greek Travel Phrases</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Greek Travel Phrases</h1>
+    <p class="description">Tap a phrase to hear the Greek pronunciation and see its meaning at a glance.</p>
+    <p id="support-message" class="support-message" aria-live="polite"></p>
+    <ul id="phrases" class="phrases" aria-live="polite"></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/phrases.json
+++ b/phrases.json
@@ -1,0 +1,52 @@
+[
+  {
+    "greek": "Γειά σου",
+    "pronunciation": "Ya sou",
+    "english": "Hello"
+  },
+  {
+    "greek": "Καλημέρα",
+    "pronunciation": "Kaliméra",
+    "english": "Good morning"
+  },
+  {
+    "greek": "Καλησπέρα",
+    "pronunciation": "Kalispera",
+    "english": "Good evening"
+  },
+  {
+    "greek": "Παρακαλώ",
+    "pronunciation": "Parakaló",
+    "english": "Please / You're welcome"
+  },
+  {
+    "greek": "Ευχαριστώ",
+    "pronunciation": "Efharistó",
+    "english": "Thank you"
+  },
+  {
+    "greek": "Ναι",
+    "pronunciation": "Ne",
+    "english": "Yes"
+  },
+  {
+    "greek": "Όχι",
+    "pronunciation": "Óhi",
+    "english": "No"
+  },
+  {
+    "greek": "Συγγνώμη",
+    "pronunciation": "Signómi",
+    "english": "Excuse me / Sorry"
+  },
+  {
+    "greek": "Μιλάτε Αγγλικά;",
+    "pronunciation": "Miláte Angliká?",
+    "english": "Do you speak English?"
+  },
+  {
+    "greek": "Πόσο κάνει;",
+    "pronunciation": "Póso káni?",
+    "english": "How much does it cost?"
+  }
+]

--- a/script.js
+++ b/script.js
@@ -1,0 +1,95 @@
+const list = document.getElementById('phrases');
+const supportMessage = document.getElementById('support-message');
+const ttsSupported = 'speechSynthesis' in window && typeof SpeechSynthesisUtterance !== 'undefined';
+let selectedVoice = null;
+
+if (!ttsSupported && supportMessage) {
+  supportMessage.textContent = 'Pronunciation playback is not available in this browser.';
+}
+
+function chooseVoice(preferredLang = 'el') {
+  if (!ttsSupported) {
+    return null;
+  }
+  const voices = window.speechSynthesis.getVoices();
+  const byLang = voices.find(voice => voice.lang && voice.lang.toLowerCase().startsWith(preferredLang));
+  return byLang || voices.find(voice => voice.lang && voice.lang.toLowerCase().includes('el')) || null;
+}
+
+function speakPhrase(phrase, button) {
+  if (!ttsSupported) {
+    return;
+  }
+  const utterance = new SpeechSynthesisUtterance(phrase.speech || phrase.greek);
+  utterance.lang = (phrase.lang || 'el-GR');
+  if (!selectedVoice || !window.speechSynthesis.getVoices().includes(selectedVoice)) {
+    selectedVoice = chooseVoice((phrase.lang || 'el').toLowerCase());
+  }
+  if (selectedVoice) {
+    utterance.voice = selectedVoice;
+  }
+  utterance.rate = phrase.rate || 0.9;
+  utterance.onstart = () => button.classList.add('is-speaking');
+  const clearSpeakingClass = () => button.classList.remove('is-speaking');
+  utterance.onend = clearSpeakingClass;
+  utterance.onerror = clearSpeakingClass;
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(utterance);
+}
+
+function renderPhrases(phrases) {
+  list.textContent = '';
+  phrases.forEach(phrase => {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'phrase-button';
+
+    const greek = document.createElement('span');
+    greek.className = 'phrase-text';
+    greek.lang = 'el';
+    greek.textContent = phrase.greek;
+
+    const pronunciation = document.createElement('span');
+    pronunciation.className = 'phrase-pronunciation';
+    if (phrase.pronunciation) {
+      pronunciation.textContent = phrase.pronunciation;
+    }
+
+    const english = document.createElement('span');
+    english.className = 'phrase-english';
+    english.textContent = phrase.english;
+
+    button.append(greek);
+    if (phrase.pronunciation) {
+      button.append(pronunciation);
+    }
+    button.append(english);
+
+    button.addEventListener('click', () => speakPhrase(phrase, button));
+    li.append(button);
+    list.append(li);
+  });
+}
+
+fetch('phrases.json')
+  .then(response => {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  })
+  .then(renderPhrases)
+  .catch(error => {
+    console.error('Failed to load phrases', error);
+    if (supportMessage) {
+      supportMessage.textContent = 'Unable to load the phrases list. Please try again later.';
+    }
+  });
+
+if (ttsSupported) {
+  window.speechSynthesis.addEventListener('voiceschanged', () => {
+    selectedVoice = chooseVoice();
+  });
+  selectedVoice = chooseVoice();
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+  background-color: #f3f5f9;
+  color: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+main {
+  width: 100%;
+  max-width: 640px;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-size: clamp(1.75rem, 2.6vw + 1.5rem, 2.75rem);
+}
+
+.description {
+  text-align: center;
+  margin: 0 auto 1.5rem;
+  max-width: 28rem;
+  line-height: 1.5;
+  color: #52606d;
+}
+
+.support-message {
+  text-align: center;
+  margin-bottom: 1rem;
+  color: #b44d4d;
+  min-height: 1.25rem;
+}
+
+.phrases {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.phrase-button {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  text-align: left;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  cursor: pointer;
+}
+
+.phrase-button:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.phrase-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.12);
+}
+
+.phrase-button:active {
+  transform: translateY(0);
+}
+
+.phrase-button.is-speaking {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.phrase-text {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.phrase-pronunciation {
+  font-size: 1rem;
+  color: #52606d;
+}
+
+.phrase-english {
+  font-size: 0.95rem;
+  color: #8291a5;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #0f172a;
+    color: #e2e8f0;
+  }
+
+  body {
+    background-color: inherit;
+  }
+
+  .description {
+    color: #94a3b8;
+  }
+
+  .support-message {
+    color: #f87171;
+  }
+
+  .phrase-button {
+    background: #1e293b;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .phrase-button:hover {
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .phrase-pronunciation {
+    color: #cbd5f5;
+  }
+
+  .phrase-english {
+    color: #94a3b8;
+  }
+}


### PR DESCRIPTION
## Summary
- remove bundled MP3 assets in favor of in-browser text-to-speech playback
- enhance phrase list rendering with pronunciation display and configurable speech settings
- refresh styling and documentation to describe the new configuration-driven setup

## Testing
- `python -m json.tool phrases.json`


------
https://chatgpt.com/codex/tasks/task_e_68c18dd4c420832c8aa82d9ad99e5646