### PR TITLE
Organize Greek phrases into categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <h1>Greek Travel Phrases</h1>
     <p class="description">Tap a phrase to hear the Greek pronunciation and see its meaning at a glance.</p>
     <p id="support-message" class="support-message" aria-live="polite"></p>
-    <ul id="phrases" class="phrases" aria-live="polite"></ul>
+    <div id="phrase-groups" class="phrase-groups" aria-live="polite"></div>
   </main>
   <script src="script.js"></script>
 </body>

--- a/phrases.json
+++ b/phrases.json
@@ -1,52 +1,252 @@
 [
   {
-    "greek": "Γειά σου",
-    "pronunciation": "Ya sou",
-    "english": "Hello"
+    "category": "Greetings & Essentials",
+    "description": "Key greetings and polite expressions for everyday encounters.",
+    "phrases": [
+      {
+        "greek": "Γειά σου",
+        "pronunciation": "Ya sou",
+        "english": "Hello (informal)"
+      },
+      {
+        "greek": "Γειά σας",
+        "pronunciation": "Ya sas",
+        "english": "Hello (formal / plural)"
+      },
+      {
+        "greek": "Καλημέρα",
+        "pronunciation": "Kaliméra",
+        "english": "Good morning"
+      },
+      {
+        "greek": "Καλησπέρα",
+        "pronunciation": "Kalispera",
+        "english": "Good evening"
+      },
+      {
+        "greek": "Καληνύχτα",
+        "pronunciation": "Kaliníkhta",
+        "english": "Good night"
+      },
+      {
+        "greek": "Τι κάνετε;",
+        "pronunciation": "Ti kánete?",
+        "english": "How are you?"
+      },
+      {
+        "greek": "Καλά, ευχαριστώ.",
+        "pronunciation": "Kalá, efharistó.",
+        "english": "I'm well, thank you."
+      },
+      {
+        "greek": "Παρακαλώ",
+        "pronunciation": "Parakaló",
+        "english": "Please / You're welcome"
+      },
+      {
+        "greek": "Ευχαριστώ",
+        "pronunciation": "Efharistó",
+        "english": "Thank you"
+      },
+      {
+        "greek": "Συγγνώμη",
+        "pronunciation": "Signómi",
+        "english": "Excuse me / Sorry"
+      },
+      {
+        "greek": "Ναι",
+        "pronunciation": "Ne",
+        "english": "Yes"
+      },
+      {
+        "greek": "Όχι",
+        "pronunciation": "Óhi",
+        "english": "No"
+      }
+    ]
   },
   {
-    "greek": "Καλημέρα",
-    "pronunciation": "Kaliméra",
-    "english": "Good morning"
+    "category": "Getting Around",
+    "description": "Directions and travel phrases to help you navigate streets and transport.",
+    "phrases": [
+      {
+        "greek": "Πού είναι το ξενοδοχείο;",
+        "pronunciation": "Pou íne to xenodohío?",
+        "english": "Where is the hotel?"
+      },
+      {
+        "greek": "Πού είναι η στάση λεωφορείου;",
+        "pronunciation": "Pou íne i stási leoforíu?",
+        "english": "Where is the bus stop?"
+      },
+      {
+        "greek": "Θα ήθελα ένα ταξί, παρακαλώ.",
+        "pronunciation": "Tha íthela éna taxí, parakaló.",
+        "english": "I'd like a taxi, please."
+      },
+      {
+        "greek": "Μπορείτε να με πάτε στο αεροδρόμιο;",
+        "pronunciation": "Boríte na me páte sto aerodrómio?",
+        "english": "Can you take me to the airport?"
+      },
+      {
+        "greek": "Πόση ώρα διαρκεί;",
+        "pronunciation": "Pósi óra diarkí?",
+        "english": "How long does it take?"
+      },
+      {
+        "greek": "Μπορείτε να το γράψετε;",
+        "pronunciation": "Boríte na to grápsete?",
+        "english": "Could you write it down?"
+      },
+      {
+        "greek": "Χάθηκα.",
+        "pronunciation": "Háthika.",
+        "english": "I'm lost."
+      },
+      {
+        "greek": "Μπορείτε να μου δείξετε στον χάρτη;",
+        "pronunciation": "Boríte na mou díxete ston hárti?",
+        "english": "Can you show me on the map?"
+      }
+    ]
   },
   {
-    "greek": "Καλησπέρα",
-    "pronunciation": "Kalispera",
-    "english": "Good evening"
+    "category": "Dining & Food",
+    "description": "Order confidently and share dietary needs while eating out.",
+    "phrases": [
+      {
+        "greek": "Ένα τραπέζι για δύο, παρακαλώ.",
+        "pronunciation": "Éna trapézi gia dýo, parakaló.",
+        "english": "A table for two, please."
+      },
+      {
+        "greek": "Θα ήθελα το μενού, παρακαλώ.",
+        "pronunciation": "Tha íthela to menoú, parakaló.",
+        "english": "I'd like the menu, please."
+      },
+      {
+        "greek": "Τι προτείνετε;",
+        "pronunciation": "Ti proteínete?",
+        "english": "What do you recommend?"
+      },
+      {
+        "greek": "Το λογαριασμό, παρακαλώ.",
+        "pronunciation": "To logariasmó, parakaló.",
+        "english": "The bill, please."
+      },
+      {
+        "greek": "Νερό, παρακαλώ.",
+        "pronunciation": "Neró, parakaló.",
+        "english": "Water, please."
+      },
+      {
+        "greek": "Είμαι χορτοφάγος.",
+        "pronunciation": "Íme hortofágos.",
+        "english": "I'm vegetarian."
+      },
+      {
+        "greek": "Έχω αλλεργία στα φιστίκια.",
+        "pronunciation": "Ého allergía sta fistíkia.",
+        "english": "I'm allergic to peanuts."
+      },
+      {
+        "greek": "Χωρίς πάγο, παρακαλώ.",
+        "pronunciation": "Horís págo, parakaló.",
+        "english": "No ice, please."
+      }
+    ]
   },
   {
-    "greek": "Παρακαλώ",
-    "pronunciation": "Parakaló",
-    "english": "Please / You're welcome"
+    "category": "Shopping & Money",
+    "description": "Useful questions for prices, payments, and finding the right item.",
+    "phrases": [
+      {
+        "greek": "Πόσο κάνει αυτό;",
+        "pronunciation": "Póso káni aftó?",
+        "english": "How much is this?"
+      },
+      {
+        "greek": "Μπορείτε να μου κάνετε μια καλύτερη τιμή;",
+        "pronunciation": "Boríte na mou kánete mia kalýteri timí?",
+        "english": "Can you give me a better price?"
+      },
+      {
+        "greek": "Δέχεστε κάρτα;",
+        "pronunciation": "Déheste kárta?",
+        "english": "Do you accept card?"
+      },
+      {
+        "greek": "Μπορώ να πληρώσω με μετρητά;",
+        "pronunciation": "Boró na pliróso me metritá?",
+        "english": "Can I pay with cash?"
+      },
+      {
+        "greek": "Θα το πάρω.",
+        "pronunciation": "Tha to páro.",
+        "english": "I'll take it."
+      },
+      {
+        "greek": "Ψάχνω για ένα σουβενίρ.",
+        "pronunciation": "Psáhno gia éna souvenir.",
+        "english": "I'm looking for a souvenir."
+      },
+      {
+        "greek": "Έχετε άλλο χρώμα;",
+        "pronunciation": "Éhete állo hróma?",
+        "english": "Do you have another color?"
+      },
+      {
+        "greek": "Μπορώ να το δοκιμάσω;",
+        "pronunciation": "Boró na to dokimáso?",
+        "english": "Can I try it on?"
+      }
+    ]
   },
   {
-    "greek": "Ευχαριστώ",
-    "pronunciation": "Efharistó",
-    "english": "Thank you"
-  },
-  {
-    "greek": "Ναι",
-    "pronunciation": "Ne",
-    "english": "Yes"
-  },
-  {
-    "greek": "Όχι",
-    "pronunciation": "Óhi",
-    "english": "No"
-  },
-  {
-    "greek": "Συγγνώμη",
-    "pronunciation": "Signómi",
-    "english": "Excuse me / Sorry"
-  },
-  {
-    "greek": "Μιλάτε Αγγλικά;",
-    "pronunciation": "Miláte Angliká?",
-    "english": "Do you speak English?"
-  },
-  {
-    "greek": "Πόσο κάνει;",
-    "pronunciation": "Póso káni?",
-    "english": "How much does it cost?"
+    "category": "Emergencies & Health",
+    "description": "Stay safe with phrases for urgent situations and communication help.",
+    "phrases": [
+      {
+        "greek": "Βοήθεια!",
+        "pronunciation": "Voítheia!",
+        "english": "Help!"
+      },
+      {
+        "greek": "Καλέστε ασθενοφόρο!",
+        "pronunciation": "Kaléste asthenofóro!",
+        "english": "Call an ambulance!"
+      },
+      {
+        "greek": "Χρειάζομαι γιατρό.",
+        "pronunciation": "Hriazóme giatró.",
+        "english": "I need a doctor."
+      },
+      {
+        "greek": "Πού είναι το νοσοκομείο;",
+        "pronunciation": "Pou íne to nosokomío?",
+        "english": "Where is the hospital?"
+      },
+      {
+        "greek": "Έχασα το διαβατήριό μου.",
+        "pronunciation": "Éhasa to diavatírio mou.",
+        "english": "I lost my passport."
+      },
+      {
+        "greek": "Υπάρχει φαρμακείο κοντά;",
+        "pronunciation": "Ipárhi farmakeío kondá?",
+        "english": "Is there a pharmacy nearby?"
+      },
+      {
+        "greek": "Μπορείτε να μιλήσετε πιο αργά;",
+        "pronunciation": "Boríte na milísete pio argá?",
+        "english": "Can you speak more slowly?"
+      },
+      {
+        "greek": "Δεν μιλάω πολύ καλά ελληνικά.",
+        "pronunciation": "Den miláo polí kalá elliniká.",
+        "english": "I don't speak Greek very well."
+      }
+    ]
   }
 ]

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const list = document.getElementById('phrases');
+const groupsContainer = document.getElementById('phrase-groups');
 const supportMessage = document.getElementById('support-message');
 const ttsSupported = 'speechSynthesis' in window && typeof SpeechSynthesisUtterance !== 'undefined';
 let selectedVoice = null;
@@ -37,38 +37,120 @@ function speakPhrase(phrase, button) {
   window.speechSynthesis.speak(utterance);
 }
 
-function renderPhrases(phrases) {
-  list.textContent = '';
-  phrases.forEach(phrase => {
-    const li = document.createElement('li');
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'phrase-button';
+function normalizeGroups(data) {
+  if (!data) {
+    return [];
+  }
 
-    const greek = document.createElement('span');
-    greek.className = 'phrase-text';
-    greek.lang = 'el';
-    greek.textContent = phrase.greek;
+  if (Array.isArray(data)) {
+    const looksLikeGroups = data.every(
+      item => item && typeof item === 'object' && Array.isArray(item.phrases)
+    );
 
-    const pronunciation = document.createElement('span');
-    pronunciation.className = 'phrase-pronunciation';
-    if (phrase.pronunciation) {
-      pronunciation.textContent = phrase.pronunciation;
+    if (looksLikeGroups) {
+      return data;
     }
 
-    const english = document.createElement('span');
-    english.className = 'phrase-english';
-    english.textContent = phrase.english;
-
-    button.append(greek);
-    if (phrase.pronunciation) {
-      button.append(pronunciation);
+    const phrases = data.filter(item => item && typeof item === 'object');
+    if (!phrases.length) {
+      return [];
     }
-    button.append(english);
 
-    button.addEventListener('click', () => speakPhrase(phrase, button));
-    li.append(button);
-    list.append(li);
+    return [
+      {
+        category: 'Common phrases',
+        phrases
+      }
+    ];
+  }
+
+  if (typeof data === 'object' && Array.isArray(data.phrases)) {
+    return [data];
+  }
+
+  return [];
+}
+
+function createPhraseListItem(phrase) {
+  const li = document.createElement('li');
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'phrase-button';
+
+  const greek = document.createElement('span');
+  greek.className = 'phrase-text';
+  greek.lang = 'el';
+  greek.textContent = phrase.greek;
+
+  const pronunciation = document.createElement('span');
+  pronunciation.className = 'phrase-pronunciation';
+  if (phrase.pronunciation) {
+    pronunciation.textContent = phrase.pronunciation;
+  }
+
+  const english = document.createElement('span');
+  english.className = 'phrase-english';
+  english.textContent = phrase.english;
+
+  button.append(greek);
+  if (phrase.pronunciation) {
+    button.append(pronunciation);
+  }
+  button.append(english);
+
+  button.addEventListener('click', () => speakPhrase(phrase, button));
+  li.append(button);
+  return li;
+}
+
+function renderPhrases(data) {
+  if (!groupsContainer) {
+    return;
+  }
+
+  groupsContainer.textContent = '';
+  const groups = normalizeGroups(data).filter(
+    group => Array.isArray(group.phrases) && group.phrases.length
+  );
+
+  if (!groups.length) {
+    const emptyMessage = document.createElement('p');
+    emptyMessage.className = 'empty-state';
+    emptyMessage.textContent = 'No phrases are available right now.';
+    groupsContainer.append(emptyMessage);
+    return;
+  }
+
+  groups.forEach(group => {
+    const section = document.createElement('section');
+    section.className = 'phrase-group';
+
+    if (group.category) {
+      const heading = document.createElement('h2');
+      heading.className = 'phrase-group-title';
+      heading.textContent = group.category;
+      section.append(heading);
+    }
+
+    if (group.description) {
+      const description = document.createElement('p');
+      description.className = 'phrase-group-description';
+      description.textContent = group.description;
+      section.append(description);
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'phrases';
+    group.phrases.forEach(phrase => {
+      if (phrase && typeof phrase === 'object' && phrase.greek && phrase.english) {
+        list.append(createPhraseListItem(phrase));
+      }
+    });
+
+    if (list.children.length) {
+      section.append(list);
+      groupsContainer.append(section);
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -43,6 +43,29 @@ h1 {
   min-height: 1.25rem;
 }
 
+.phrase-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+}
+
+.phrase-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.phrase-group-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.25vw + 1.1rem, 1.85rem);
+}
+
+.phrase-group-description {
+  margin: 0;
+  color: #52606d;
+  line-height: 1.5;
+}
+
 .phrases {
   list-style: none;
   margin: 0;
@@ -50,6 +73,12 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.empty-state {
+  margin: 0;
+  text-align: center;
+  color: #52606d;
 }
 
 .phrase-button {
@@ -116,6 +145,14 @@ h1 {
 
   .support-message {
     color: #f87171;
+  }
+
+  .phrase-group-description {
+    color: #94a3b8;
+  }
+
+  .empty-state {
+    color: #94a3b8;
   }
 
   .phrase-button {


### PR DESCRIPTION
## Summary
- organize the phrase data into themed categories with optional descriptions
- update the layout and rendering logic to show grouped headings while keeping text-to-speech support
- expand the catalog with additional travel, dining, shopping, and emergency phrases

## Testing
- python -m json.tool greek-phrases/phrases.json

------
https://chatgpt.com/codex/tasks/task_e_68cc3234d7c0832cbfe0fd521dcb84fc