### PR TITLE
Make phrase groups collapsible and improve mobile layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,22 +121,49 @@ function renderPhrases(data) {
     return;
   }
 
-  groups.forEach(group => {
+  const collapseOnMobile =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 640px)').matches;
+
+  groups.forEach((group, groupIndex) => {
     const section = document.createElement('section');
     section.className = 'phrase-group';
 
-    if (group.category) {
-      const heading = document.createElement('h2');
-      heading.className = 'phrase-group-title';
-      heading.textContent = group.category;
-      section.append(heading);
-    }
+    const heading = document.createElement('h2');
+    heading.className = 'phrase-group-heading';
+
+    const toggleButton = document.createElement('button');
+    toggleButton.type = 'button';
+    toggleButton.className = 'phrase-group-toggle';
+
+    const contentId = `phrase-group-content-${groupIndex}`;
+    toggleButton.setAttribute('aria-controls', contentId);
+
+    const title = document.createElement('span');
+    title.className = 'phrase-group-title';
+    title.textContent = group.category || `Phrase group ${groupIndex + 1}`;
+    toggleButton.append(title);
+
+    const icon = document.createElement('span');
+    icon.className = 'phrase-group-toggle-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.innerHTML =
+      '<svg viewBox="0 0 12 8" width="12" height="8" focusable="false" aria-hidden="true"><path d="M1 1l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    toggleButton.append(icon);
+
+    heading.append(toggleButton);
+    section.append(heading);
+
+    const content = document.createElement('div');
+    content.className = 'phrase-group-content';
+    content.id = contentId;
 
     if (group.description) {
       const description = document.createElement('p');
       description.className = 'phrase-group-description';
       description.textContent = group.description;
-      section.append(description);
+      content.append(description);
     }
 
     const list = document.createElement('ul');
@@ -148,7 +175,25 @@ function renderPhrases(data) {
     });
 
     if (list.children.length) {
-      section.append(list);
+      content.append(list);
+      section.append(content);
+
+      const startCollapsed = collapseOnMobile && groupIndex > 0;
+      if (startCollapsed) {
+        section.classList.add('is-collapsed');
+        toggleButton.setAttribute('aria-expanded', 'false');
+        content.hidden = true;
+      } else {
+        toggleButton.setAttribute('aria-expanded', 'true');
+        content.hidden = false;
+      }
+
+      toggleButton.addEventListener('click', () => {
+        const collapsed = section.classList.toggle('is-collapsed');
+        toggleButton.setAttribute('aria-expanded', String(!collapsed));
+        content.hidden = collapsed;
+      });
+
       groupsContainer.append(section);
     }
   });

--- a/style.css
+++ b/style.css
@@ -14,7 +14,8 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  padding: 2rem 1rem 3rem;
+  padding: clamp(1rem, 5vw, 2.5rem) clamp(0.75rem, 4vw, 1.75rem)
+    clamp(2.25rem, 6vw, 3.5rem);
 }
 
 main {
@@ -46,18 +47,66 @@ h1 {
 .phrase-groups {
   display: flex;
   flex-direction: column;
-  gap: 2.25rem;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .phrase-group {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.phrase-group-heading {
+  margin: 0;
+}
+
+.phrase-group-toggle {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: clamp(1rem, 3vw + 0.75rem, 1.5rem)
+    clamp(1rem, 4vw, 1.75rem);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  line-height: 1.2;
+  touch-action: manipulation;
+  transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+.phrase-group-toggle:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.phrase-group-toggle:active {
+  background: rgba(37, 99, 235, 0.14);
+}
+
+.phrase-group-toggle:hover .phrase-group-toggle-icon,
+.phrase-group-toggle:active .phrase-group-toggle-icon {
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.phrase-group-toggle:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: -2px;
+  border-radius: 16px;
 }
 
 .phrase-group-title {
   margin: 0;
   font-size: clamp(1.25rem, 1.25vw + 1.1rem, 1.85rem);
+  line-height: 1.2;
 }
 
 .phrase-group-description {
@@ -66,13 +115,48 @@ h1 {
   line-height: 1.5;
 }
 
+.phrase-group-content {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0 clamp(1rem, 4vw, 1.75rem)
+    clamp(1.25rem, 4vw, 1.85rem);
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.phrase-group-toggle-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #2563eb;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.phrase-group-toggle-icon svg {
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+.phrase-group.is-collapsed .phrase-group-toggle-icon svg {
+  transform: rotate(-90deg);
+}
+
+.phrase-group.is-collapsed .phrase-group-toggle {
+  border-bottom: none;
+}
+
 .phrases {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: clamp(0.65rem, 2.5vw, 0.9rem);
 }
 
 .empty-state {
@@ -85,15 +169,16 @@ h1 {
   width: 100%;
   border: none;
   border-radius: 14px;
-  padding: 1rem 1.25rem;
+  padding: clamp(0.85rem, 3vw, 1.2rem) clamp(1rem, 4vw, 1.5rem);
   background: #ffffff;
   box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
   text-align: left;
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.35rem;
+  gap: clamp(0.25rem, 2vw, 0.45rem);
   transition: transform 0.12s ease, box-shadow 0.12s ease;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .phrase-button:focus-visible {
@@ -115,18 +200,28 @@ h1 {
 }
 
 .phrase-text {
-  font-size: 1.4rem;
+  font-size: clamp(1.2rem, 3vw + 1rem, 1.4rem);
   font-weight: 600;
 }
 
 .phrase-pronunciation {
-  font-size: 1rem;
+  font-size: clamp(0.95rem, 2.5vw, 1rem);
   color: #52606d;
 }
 
 .phrase-english {
-  font-size: 0.95rem;
+  font-size: clamp(0.9rem, 2.2vw, 0.95rem);
   color: #8291a5;
+}
+
+@media (max-width: 600px) {
+  .phrase-group {
+    border-radius: 16px;
+  }
+
+  .phrase-group-content {
+    padding-bottom: clamp(1rem, 6vw, 1.5rem);
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -151,6 +246,34 @@ h1 {
     color: #94a3b8;
   }
 
+  .phrase-group {
+    background: rgba(15, 23, 42, 0.82);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+  }
+
+  .phrase-group-toggle:hover {
+    background: rgba(59, 130, 246, 0.18);
+  }
+
+  .phrase-group-toggle:active {
+    background: rgba(59, 130, 246, 0.28);
+  }
+
+  .phrase-group-toggle:hover .phrase-group-toggle-icon,
+  .phrase-group-toggle:active .phrase-group-toggle-icon {
+    background: rgba(59, 130, 246, 0.35);
+  }
+
+  .phrase-group-content {
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .phrase-group-toggle-icon {
+    background: rgba(59, 130, 246, 0.24);
+    color: #93c5fd;
+  }
+
   .empty-state {
     color: #94a3b8;
   }
@@ -170,5 +293,16 @@ h1 {
 
   .phrase-english {
     color: #94a3b8;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- add accessible toggle controls so each phrase group can collapse or expand, defaulting to collapsed on smaller viewports
- refresh the card styling and spacing with responsive padding, typography, and touch targets for a friendlier mobile experience

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdbc35b6e4832c82eff9f356a5b373