### PR TITLE
Fix collapsible sections on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -178,20 +178,27 @@ function renderPhrases(data) {
       content.append(list);
       section.append(content);
 
+      const setCollapsedState = collapsed => {
+        section.classList.toggle('is-collapsed', collapsed);
+        toggleButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        if (collapsed) {
+          content.hidden = true;
+          content.setAttribute('aria-hidden', 'true');
+          content.style.display = 'none';
+        } else {
+          content.hidden = false;
+          content.removeAttribute('hidden');
+          content.removeAttribute('aria-hidden');
+          content.style.display = '';
+        }
+      };
+
       const startCollapsed = collapseOnMobile && groupIndex > 0;
-      if (startCollapsed) {
-        section.classList.add('is-collapsed');
-        toggleButton.setAttribute('aria-expanded', 'false');
-        content.hidden = true;
-      } else {
-        toggleButton.setAttribute('aria-expanded', 'true');
-        content.hidden = false;
-      }
+      setCollapsedState(startCollapsed);
 
       toggleButton.addEventListener('click', () => {
-        const collapsed = section.classList.toggle('is-collapsed');
-        toggleButton.setAttribute('aria-expanded', String(!collapsed));
-        content.hidden = collapsed;
+        const nextCollapsed = !section.classList.contains('is-collapsed');
+        setCollapsedState(nextCollapsed);
       });
 
       groupsContainer.append(section);

--- a/style.css
+++ b/style.css
@@ -118,9 +118,13 @@ h1 {
 .phrase-group-content {
   display: grid;
   gap: 0.85rem;
-  padding: 0 clamp(1rem, 4vw, 1.75rem)
+  padding: clamp(0.85rem, 3vw, 1.4rem) clamp(1rem, 4vw, 1.75rem)
     clamp(1.25rem, 4vw, 1.85rem);
   border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.phrase-group.is-collapsed .phrase-group-content {
+  display: none;
 }
 
 .phrase-group-toggle-icon {


### PR DESCRIPTION
## Summary
- ensure the collapsible group state is managed through a shared helper so aria attributes, the hidden flag, and display styles stay in sync
- add a CSS fallback to hide collapsed content and adjust padding so group descriptions breathe on small screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cff8da0f64832c9b056aff4dc38439