### PR TITLE
Refocus site on targeted vocabulary practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Greek Travel Phrases</title>
+  <title>Greek Vocabulary Practice</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <main>
-    <h1>Greek Travel Phrases</h1>
-    <p class="description">Tap a phrase to hear the Greek pronunciation and see its meaning at a glance.</p>
+    <h1>Targeted Greek Vocabulary Practice</h1>
+    <p class="description">Review the words you already know, hear their pronunciation, and see them in action inside short example phrases.</p>
     <p id="support-message" class="support-message" aria-live="polite"></p>
-    <div id="phrase-groups" class="phrase-groups" aria-live="polite"></div>
+    <div id="practice-groups" class="practice-groups" aria-live="polite"></div>
   </main>
   <script src="script.js"></script>
 </body>

--- a/phrases.json
+++ b/phrases.json
@@ -1,251 +1,401 @@
 [
   {
-    "category": "Greetings & Essentials",
-    "description": "Key greetings and polite expressions for everyday encounters.",
-    "phrases": [
+    "category": "Greetings",
+    "description": "Practice core greetings and polite replies you already know, and see how they work inside short phrases.",
+    "rows": [
       {
-        "greek": "Γειά σου",
-        "pronunciation": "Ya sou",
-        "english": "Hello (informal)"
+        "title": "Γειά σου / Γειά σας",
+        "summary": "Hello (informal / formal)",
+        "variants": [
+          {
+            "greek": "Γειά σου",
+            "pronunciation": "Ya sou",
+            "english": "Hello (informal)",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Γειά σας",
+            "pronunciation": "Ya sas",
+            "english": "Hello (formal / plural)",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Γειά σου, Μαρία!",
+            "pronunciation": "Ya sou, María!",
+            "english": "Hello, Maria!",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Γειά σας, κύριε Παπαδόπουλε.",
+            "pronunciation": "Ya sas, kírie Papadópoule.",
+            "english": "Hello, Mr. Papadopoulos.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Γειά σας",
-        "pronunciation": "Ya sas",
-        "english": "Hello (formal / plural)"
+        "title": "Καλημέρα / Καλησπέρα / Καληνύχτα",
+        "summary": "Good morning / evening / night",
+        "variants": [
+          {
+            "greek": "Καλημέρα",
+            "pronunciation": "Kaliméra",
+            "english": "Good morning",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Καλησπέρα",
+            "pronunciation": "Kalispera",
+            "english": "Good evening",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Καληνύχτα",
+            "pronunciation": "Kaliníkhta",
+            "english": "Good night",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Καλημέρα, τι κάνετε;",
+            "pronunciation": "Kaliméra, ti kánete;",
+            "english": "Good morning, how are you?",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ραντεβού στις οκτώ; Καλησπέρα!",
+            "pronunciation": "Rantevú stis októ? Kalispera!",
+            "english": "Meeting at eight? Good evening!",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Καληνύχτα, τα λέμε αύριο.",
+            "pronunciation": "Kaliníkhta, ta léme ávrio.",
+            "english": "Good night, see you tomorrow.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Καλημέρα",
-        "pronunciation": "Kaliméra",
-        "english": "Good morning"
+        "title": "Τι κάνετε; / Καλά",
+        "summary": "How are you? / Well",
+        "variants": [
+          {
+            "greek": "Τι κάνετε;",
+            "pronunciation": "Ti kánete;",
+            "english": "How are you?",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Καλά",
+            "pronunciation": "Kalá",
+            "english": "Well / fine",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Τι κάνετε σήμερα;",
+            "pronunciation": "Ti kánete símera;",
+            "english": "How are you today?",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Είμαι καλά, ευχαριστώ.",
+            "pronunciation": "Íme kalá, efharistó.",
+            "english": "I'm well, thank you.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Όλα καλά εδώ!",
+            "pronunciation": "Óla kalá edó!",
+            "english": "Everything is good here!",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Καλησπέρα",
-        "pronunciation": "Kalispera",
-        "english": "Good evening"
+        "title": "Παρακαλώ / Ευχαριστώ",
+        "summary": "Please / Thank you",
+        "variants": [
+          {
+            "greek": "Παρακαλώ",
+            "pronunciation": "Parakaló",
+            "english": "Please / you're welcome",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ευχαριστώ",
+            "pronunciation": "Efharistó",
+            "english": "Thank you",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ένα νερό, παρακαλώ.",
+            "pronunciation": "Éna neró, parakaló.",
+            "english": "One water, please.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ευχαριστώ για τη βοήθεια.",
+            "pronunciation": "Efharistó gia ti voítheia.",
+            "english": "Thank you for the help.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Παρακαλώ, περάστε μέσα.",
+            "pronunciation": "Parakaló, peráste mésa.",
+            "english": "Please, come inside.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Καληνύχτα",
-        "pronunciation": "Kaliníkhta",
-        "english": "Good night"
-      },
-      {
-        "greek": "Τι κάνετε;",
-        "pronunciation": "Ti kánete?",
-        "english": "How are you?"
-      },
-      {
-        "greek": "Καλά, ευχαριστώ.",
-        "pronunciation": "Kalá, efharistó.",
-        "english": "I'm well, thank you."
-      },
-      {
-        "greek": "Παρακαλώ",
-        "pronunciation": "Parakaló",
-        "english": "Please / You're welcome"
-      },
-      {
-        "greek": "Ευχαριστώ",
-        "pronunciation": "Efharistó",
-        "english": "Thank you"
-      },
-      {
-        "greek": "Συγγνώμη",
-        "pronunciation": "Signómi",
-        "english": "Excuse me / Sorry"
-      },
-      {
-        "greek": "Ναι",
-        "pronunciation": "Ne",
-        "english": "Yes"
-      },
-      {
-        "greek": "Όχι",
-        "pronunciation": "Óhi",
-        "english": "No"
+        "title": "Συγγνώμη",
+        "summary": "Excuse me / Sorry",
+        "variants": [
+          {
+            "greek": "Συγγνώμη",
+            "pronunciation": "Signómi",
+            "english": "Excuse me / Sorry",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Συγγνώμη, δεν άκουσα.",
+            "pronunciation": "Signómi, den ákousa.",
+            "english": "Sorry, I didn't hear.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Συγγνώμη, είναι ελεύθερη η θέση;",
+            "pronunciation": "Signómi, íne eléftheri i thési;",
+            "english": "Excuse me, is the seat free?",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Συγγνώμη για την καθυστέρηση.",
+            "pronunciation": "Signómi gia tin kathistérisi.",
+            "english": "Sorry for the delay.",
+            "lang": "el-GR"
+          }
+        ]
       }
     ]
   },
   {
-    "category": "Getting Around",
-    "description": "Directions and travel phrases to help you navigate streets and transport.",
-    "phrases": [
+    "category": "Articles & Key Words",
+    "description": "Keep essential little words ready so you can answer quickly and build longer sentences.",
+    "rows": [
       {
-        "greek": "Πού είναι το ξενοδοχείο;",
-        "pronunciation": "Pou íne to xenodohío?",
-        "english": "Where is the hotel?"
+        "title": "Ναι / Όχι",
+        "summary": "Yes / No",
+        "variants": [
+          {
+            "greek": "Ναι",
+            "pronunciation": "Ne",
+            "english": "Yes",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Όχι",
+            "pronunciation": "Óhi",
+            "english": "No",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ναι, θέλω καφέ.",
+            "pronunciation": "Ne, thélo kafé.",
+            "english": "Yes, I want coffee.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Όχι, ευχαριστώ.",
+            "pronunciation": "Óhi, efharistó.",
+            "english": "No, thank you.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ναι, φυσικά!",
+            "pronunciation": "Ne, fysiká!",
+            "english": "Yes, of course!",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Πού είναι η στάση λεωφορείου;",
-        "pronunciation": "Pou íne i stási leoforíu?",
-        "english": "Where is the bus stop?"
+        "title": "Είναι",
+        "summary": "Is",
+        "variants": [
+          {
+            "greek": "Είναι",
+            "pronunciation": "Íne",
+            "english": "Is",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Αυτό είναι ωραίο.",
+            "pronunciation": "Aftó íne oréo.",
+            "english": "This is nice.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Η παραλία είναι κοντά.",
+            "pronunciation": "I paralía íne kondá.",
+            "english": "The beach is close.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Πού είναι το μουσείο;",
+            "pronunciation": "Poú íne to mousío;",
+            "english": "Where is the museum?",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Θα ήθελα ένα ταξί, παρακαλώ.",
-        "pronunciation": "Tha íthela éna taxí, parakaló.",
-        "english": "I'd like a taxi, please."
+        "title": "Κάνει",
+        "summary": "Makes / Does",
+        "variants": [
+          {
+            "greek": "Κάνει",
+            "pronunciation": "Káni",
+            "english": "Makes / does",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Κάνει ζέστη σήμερα.",
+            "pronunciation": "Káni zésti símera.",
+            "english": "It's hot today.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Τι κάνει ο φίλος σου;",
+            "pronunciation": "Ti káni o fílos sou;",
+            "english": "How is your friend doing?",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Κάνει καλή δουλειά.",
+            "pronunciation": "Káni kalí dhuliá.",
+            "english": "He/She does a good job.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Μπορείτε να με πάτε στο αεροδρόμιο;",
-        "pronunciation": "Boríte na me páte sto aerodrómio?",
-        "english": "Can you take me to the airport?"
+        "title": "Στο",
+        "summary": "At / In the",
+        "variants": [
+          {
+            "greek": "Στο",
+            "pronunciation": "Sto",
+            "english": "At / in the",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Είμαστε στο μουσείο.",
+            "pronunciation": "Ímaste sto mousío.",
+            "english": "We are at the museum.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ραντεβού στο πάρκο.",
+            "pronunciation": "Rantevú sto párko.",
+            "english": "Meeting at the park.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Το δωμάτιο είναι στο δεύτερο όροφο.",
+            "pronunciation": "To dhomátio íne sto déftero órofo.",
+            "english": "The room is on the second floor.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Πόση ώρα διαρκεί;",
-        "pronunciation": "Pósi óra diarkí?",
-        "english": "How long does it take?"
+        "title": "Θα ήθελα",
+        "summary": "I would like",
+        "variants": [
+          {
+            "greek": "Θα ήθελα",
+            "pronunciation": "Tha íthela",
+            "english": "I would like",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Θα ήθελα έναν καφέ.",
+            "pronunciation": "Tha íthela énan kafé.",
+            "english": "I would like a coffee.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Θα ήθελα να κλείσω τραπέζι.",
+            "pronunciation": "Tha íthela na kleíso trapézi.",
+            "english": "I would like to book a table.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Θα ήθελα να ρωτήσω κάτι.",
+            "pronunciation": "Tha íthela na rotíso káti.",
+            "english": "I would like to ask something.",
+            "lang": "el-GR"
+          }
+        ]
       },
       {
-        "greek": "Μπορείτε να το γράψετε;",
-        "pronunciation": "Boríte na to grápsete?",
-        "english": "Could you write it down?"
-      },
-      {
-        "greek": "Χάθηκα.",
-        "pronunciation": "Háthika.",
-        "english": "I'm lost."
-      },
-      {
-        "greek": "Μπορείτε να μου δείξετε στον χάρτη;",
-        "pronunciation": "Boríte na mou díxete ston hárti?",
-        "english": "Can you show me on the map?"
-      }
-    ]
-  },
-  {
-    "category": "Dining & Food",
-    "description": "Order confidently and share dietary needs while eating out.",
-    "phrases": [
-      {
-        "greek": "Ένα τραπέζι για δύο, παρακαλώ.",
-        "pronunciation": "Éna trapézi gia dýo, parakaló.",
-        "english": "A table for two, please."
-      },
-      {
-        "greek": "Θα ήθελα το μενού, παρακαλώ.",
-        "pronunciation": "Tha íthela to menoú, parakaló.",
-        "english": "I'd like the menu, please."
-      },
-      {
-        "greek": "Τι προτείνετε;",
-        "pronunciation": "Ti proteínete?",
-        "english": "What do you recommend?"
-      },
-      {
-        "greek": "Το λογαριασμό, παρακαλώ.",
-        "pronunciation": "To logariasmó, parakaló.",
-        "english": "The bill, please."
-      },
-      {
-        "greek": "Νερό, παρακαλώ.",
-        "pronunciation": "Neró, parakaló.",
-        "english": "Water, please."
-      },
-      {
-        "greek": "Είμαι χορτοφάγος.",
-        "pronunciation": "Íme hortofágos.",
-        "english": "I'm vegetarian."
-      },
-      {
-        "greek": "Έχω αλλεργία στα φιστίκια.",
-        "pronunciation": "Ého allergía sta fistíkia.",
-        "english": "I'm allergic to peanuts."
-      },
-      {
-        "greek": "Χωρίς πάγο, παρακαλώ.",
-        "pronunciation": "Horís págo, parakaló.",
-        "english": "No ice, please."
-      }
-    ]
-  },
-  {
-    "category": "Shopping & Money",
-    "description": "Useful questions for prices, payments, and finding the right item.",
-    "phrases": [
-      {
-        "greek": "Πόσο κάνει αυτό;",
-        "pronunciation": "Póso káni aftó?",
-        "english": "How much is this?"
-      },
-      {
-        "greek": "Μπορείτε να μου κάνετε μια καλύτερη τιμή;",
-        "pronunciation": "Boríte na mou kánete mia kalýteri timí?",
-        "english": "Can you give me a better price?"
-      },
-      {
-        "greek": "Δέχεστε κάρτα;",
-        "pronunciation": "Déheste kárta?",
-        "english": "Do you accept card?"
-      },
-      {
-        "greek": "Μπορώ να πληρώσω με μετρητά;",
-        "pronunciation": "Boró na pliróso me metritá?",
-        "english": "Can I pay with cash?"
-      },
-      {
-        "greek": "Θα το πάρω.",
-        "pronunciation": "Tha to páro.",
-        "english": "I'll take it."
-      },
-      {
-        "greek": "Ψάχνω για ένα σουβενίρ.",
-        "pronunciation": "Psáhno gia éna souvenir.",
-        "english": "I'm looking for a souvenir."
-      },
-      {
-        "greek": "Έχετε άλλο χρώμα;",
-        "pronunciation": "Éhete állo hróma?",
-        "english": "Do you have another color?"
-      },
-      {
-        "greek": "Μπορώ να το δοκιμάσω;",
-        "pronunciation": "Boró na to dokimáso?",
-        "english": "Can I try it on?"
-      }
-    ]
-  },
-  {
-    "category": "Emergencies & Health",
-    "description": "Stay safe with phrases for urgent situations and communication help.",
-    "phrases": [
-      {
-        "greek": "Βοήθεια!",
-        "pronunciation": "Voítheia!",
-        "english": "Help!"
-      },
-      {
-        "greek": "Καλέστε ασθενοφόρο!",
-        "pronunciation": "Kaléste asthenofóro!",
-        "english": "Call an ambulance!"
-      },
-      {
-        "greek": "Χρειάζομαι γιατρό.",
-        "pronunciation": "Hriazóme giatró.",
-        "english": "I need a doctor."
-      },
-      {
-        "greek": "Πού είναι το νοσοκομείο;",
-        "pronunciation": "Pou íne to nosokomío?",
-        "english": "Where is the hospital?"
-      },
-      {
-        "greek": "Έχασα το διαβατήριό μου.",
-        "pronunciation": "Éhasa to diavatírio mou.",
-        "english": "I lost my passport."
-      },
-      {
-        "greek": "Υπάρχει φαρμακείο κοντά;",
-        "pronunciation": "Ipárhi farmakeío kondá?",
-        "english": "Is there a pharmacy nearby?"
-      },
-      {
-        "greek": "Μπορείτε να μιλήσετε πιο αργά;",
-        "pronunciation": "Boríte na milísete pio argá?",
-        "english": "Can you speak more slowly?"
-      },
-      {
-        "greek": "Δεν μιλάω πολύ καλά ελληνικά.",
-        "pronunciation": "Den miláo polí kalá elliniká.",
-        "english": "I don't speak Greek very well."
+        "title": "Ο άντρας / Η γυναίκα",
+        "summary": "The man / The woman",
+        "variants": [
+          {
+            "greek": "Ο άντρας",
+            "pronunciation": "O ántras",
+            "english": "The man",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Η γυναίκα",
+            "pronunciation": "I yinéka",
+            "english": "The woman",
+            "lang": "el-GR"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ο άντρας διαβάζει την εφημερίδα.",
+            "pronunciation": "O ántras dhiavázi tin efimerída.",
+            "english": "The man is reading the newspaper.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Η γυναίκα περιμένει στο σταθμό.",
+            "pronunciation": "I yinéka periméni sto stathmó.",
+            "english": "The woman is waiting at the station.",
+            "lang": "el-GR"
+          },
+          {
+            "greek": "Ο άντρας και η γυναίκα χορεύουν.",
+            "pronunciation": "O ántras ke i yinéka horévoun.",
+            "english": "The man and the woman are dancing.",
+            "lang": "el-GR"
+          }
+        ]
       }
     ]
   }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: light dark;
   font-family: 'Segoe UI', Roboto, sans-serif;
-  background-color: #f3f5f9;
+  background-color: #eef2f8;
   color: #1f2933;
 }
 
@@ -14,217 +14,224 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  padding: clamp(1rem, 5vw, 2.5rem) clamp(0.75rem, 4vw, 1.75rem)
-    clamp(2.25rem, 6vw, 3.5rem);
+  padding: clamp(1rem, 5vw, 2.75rem) clamp(1.1rem, 5vw, 2.75rem)
+    clamp(3rem, 7vw, 4.25rem);
+  background-color: inherit;
 }
 
 main {
   width: 100%;
-  max-width: 640px;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2.2vw, 2.25rem);
 }
 
 h1 {
   text-align: center;
-  margin-bottom: 1rem;
-  font-size: clamp(1.75rem, 2.6vw + 1.5rem, 2.75rem);
+  margin: 0;
+  font-size: clamp(1.9rem, 2.6vw + 1.6rem, 3rem);
 }
 
 .description {
   text-align: center;
-  margin: 0 auto 1.5rem;
-  max-width: 28rem;
-  line-height: 1.5;
+  margin: 0 auto;
+  max-width: 38rem;
+  line-height: 1.6;
   color: #52606d;
 }
 
 .support-message {
   text-align: center;
-  margin-bottom: 1rem;
+  margin: 0.75rem auto 0;
   color: #b44d4d;
-  min-height: 1.25rem;
+  min-height: 1.4rem;
 }
 
-.phrase-groups {
+.practice-groups {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.25rem);
+  gap: clamp(1.75rem, 3vw, 2.75rem);
 }
 
-.phrase-group {
+.practice-section {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 26px;
+  padding: clamp(1.25rem, 2.6vw, 1.9rem) clamp(1.5rem, 3vw, 2.4rem);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 0;
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 20px;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
-  border: 1px solid rgba(15, 23, 42, 0.05);
+  gap: clamp(1.2rem, 2vw, 1.75rem);
 }
 
-.phrase-group-heading {
-  margin: 0;
-}
-
-.phrase-group-toggle {
-  width: 100%;
-  border: none;
-  background: transparent;
-  color: inherit;
+.practice-section-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: clamp(1rem, 3vw + 0.75rem, 1.5rem)
-    clamp(1rem, 4vw, 1.75rem);
-  cursor: pointer;
-  font: inherit;
-  font-weight: 600;
-  text-align: left;
-  line-height: 1.2;
-  touch-action: manipulation;
-  transition: background-color 0.18s ease, color 0.18s ease;
+  flex-direction: column;
+  gap: clamp(0.6rem, 1.4vw, 0.9rem);
 }
 
-.phrase-group-toggle:hover {
-  background: rgba(37, 99, 235, 0.08);
-}
-
-.phrase-group-toggle:active {
-  background: rgba(37, 99, 235, 0.14);
-}
-
-.phrase-group-toggle:hover .phrase-group-toggle-icon,
-.phrase-group-toggle:active .phrase-group-toggle-icon {
-  background: rgba(37, 99, 235, 0.18);
-}
-
-.phrase-group-toggle:focus-visible {
-  outline: 3px solid #2563eb;
-  outline-offset: -2px;
-  border-radius: 16px;
-}
-
-.phrase-group-title {
+.practice-section-title {
   margin: 0;
-  font-size: clamp(1.25rem, 1.25vw + 1.1rem, 1.85rem);
+  font-size: clamp(1.55rem, 2vw + 1.35rem, 2.1rem);
   line-height: 1.2;
 }
 
-.phrase-group-description {
+.practice-section-description {
   margin: 0;
   color: #52606d;
-  line-height: 1.5;
+  line-height: 1.6;
+  max-width: 42rem;
 }
 
-.phrase-group-content {
+.practice-rows {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2.2vw, 1.4rem);
+}
+
+.practice-row {
   display: grid;
-  gap: 0.85rem;
-  padding: clamp(0.85rem, 3vw, 1.4rem) clamp(1rem, 4vw, 1.75rem)
-    clamp(1.25rem, 4vw, 1.85rem);
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  gap: clamp(1rem, 2vw, 1.6rem);
+  padding: clamp(1.1rem, 2.2vw, 1.6rem);
+  background: rgba(241, 245, 249, 0.65);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.phrase-group.is-collapsed .phrase-group-content {
-  display: none;
+.practice-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.65rem, 1.8vw, 1rem);
 }
 
-.phrase-group-toggle-icon {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  background: rgba(37, 99, 235, 0.12);
-  color: #2563eb;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, background-color 0.2s ease,
-    color 0.2s ease;
-  flex-shrink: 0;
+.practice-row-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.7vw + 1rem, 1.7rem);
+  line-height: 1.3;
 }
 
-.phrase-group-toggle-icon svg {
-  display: block;
-  transition: transform 0.2s ease;
+.practice-row-summary {
+  margin: 0;
+  color: #52606d;
+  line-height: 1.6;
 }
 
-.phrase-group.is-collapsed .phrase-group-toggle-icon svg {
-  transform: rotate(-90deg);
+.practice-row-label {
+  margin: 0;
+  font-size: clamp(0.75rem, 1.2vw, 0.85rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
 }
 
-.phrase-group.is-collapsed .phrase-group-toggle {
-  border-bottom: none;
+.practice-row-variants {
+  display: grid;
+  gap: clamp(0.55rem, 1.5vw, 0.9rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
-.phrases {
+.practice-row-examples {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.65rem, 1.7vw, 0.9rem);
+}
+
+.practice-row-examples-heading {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.4vw, 1.2rem);
+  color: #2f4858;
+  font-weight: 600;
+}
+
+.example-list {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.65rem, 2.5vw, 0.9rem);
+  display: grid;
+  gap: clamp(0.7rem, 1.8vw, 1rem);
+}
+
+.speech-button {
+  width: 100%;
+  border: none;
+  border-radius: 16px;
+  padding: clamp(0.85rem, 2.4vw, 1.15rem) clamp(1rem, 2.8vw, 1.4rem);
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  text-align: left;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(0.25rem, 1.6vw, 0.4rem);
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.speech-button--compact {
+  padding: clamp(0.65rem, 2vw, 0.85rem) clamp(0.85rem, 2.5vw, 1.1rem);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.speech-button:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.speech-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+}
+
+.speech-button:active {
+  transform: translateY(0);
+}
+
+.speech-button.is-speaking {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.speech-button__text {
+  font-size: clamp(1.15rem, 2.4vw, 1.35rem);
+  font-weight: 600;
+}
+
+.speech-button__pronunciation {
+  font-size: clamp(0.92rem, 1.8vw, 1.05rem);
+  color: #52606d;
+}
+
+.speech-button__english {
+  font-size: clamp(0.85rem, 1.6vw, 0.95rem);
+  color: #7b8794;
 }
 
 .empty-state {
-  margin: 0;
+  margin: 0 auto;
   text-align: center;
   color: #52606d;
 }
 
-.phrase-button {
-  width: 100%;
-  border: none;
-  border-radius: 14px;
-  padding: clamp(0.85rem, 3vw, 1.2rem) clamp(1rem, 4vw, 1.5rem);
-  background: #ffffff;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
-  text-align: left;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: clamp(0.25rem, 2vw, 0.45rem);
-  transition: transform 0.12s ease, box-shadow 0.12s ease;
-  cursor: pointer;
-  touch-action: manipulation;
-}
+@media (min-width: 800px) {
+  .practice-row {
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+    align-items: start;
+  }
 
-.phrase-button:focus-visible {
-  outline: 3px solid #2563eb;
-  outline-offset: 2px;
-}
-
-.phrase-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.12);
-}
-
-.phrase-button:active {
-  transform: translateY(0);
-}
-
-.phrase-button.is-speaking {
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
-}
-
-.phrase-text {
-  font-size: clamp(1.2rem, 3vw + 1rem, 1.4rem);
-  font-weight: 600;
-}
-
-.phrase-pronunciation {
-  font-size: clamp(0.95rem, 2.5vw, 1rem);
-  color: #52606d;
-}
-
-.phrase-english {
-  font-size: clamp(0.9rem, 2.2vw, 0.95rem);
-  color: #8291a5;
+  .example-list {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
 }
 
 @media (max-width: 600px) {
-  .phrase-group {
-    border-radius: 16px;
+  .practice-section {
+    border-radius: 20px;
   }
 
-  .phrase-group-content {
-    padding-bottom: clamp(1rem, 6vw, 1.5rem);
+  .practice-row {
+    border-radius: 16px;
   }
 }
 
@@ -246,56 +253,55 @@ h1 {
     color: #f87171;
   }
 
-  .phrase-group-description {
-    color: #94a3b8;
-  }
-
-  .phrase-group {
+  .practice-section {
     background: rgba(15, 23, 42, 0.82);
     border: 1px solid rgba(148, 163, 184, 0.16);
-    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
   }
 
-  .phrase-group-toggle:hover {
-    background: rgba(59, 130, 246, 0.18);
-  }
-
-  .phrase-group-toggle:active {
-    background: rgba(59, 130, 246, 0.28);
-  }
-
-  .phrase-group-toggle:hover .phrase-group-toggle-icon,
-  .phrase-group-toggle:active .phrase-group-toggle-icon {
-    background: rgba(59, 130, 246, 0.35);
-  }
-
-  .phrase-group-content {
-    border-top: 1px solid rgba(148, 163, 184, 0.2);
-  }
-
-  .phrase-group-toggle-icon {
-    background: rgba(59, 130, 246, 0.24);
-    color: #93c5fd;
-  }
-
-  .empty-state {
+  .practice-section-description {
     color: #94a3b8;
   }
 
-  .phrase-button {
-    background: #1e293b;
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  .practice-row {
+    background: rgba(30, 41, 59, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.18);
   }
 
-  .phrase-button:hover {
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.5);
-  }
-
-  .phrase-pronunciation {
+  .practice-row-summary {
     color: #cbd5f5;
   }
 
-  .phrase-english {
+  .practice-row-label {
+    color: #a5b4fc;
+  }
+
+  .practice-row-examples-heading {
+    color: #bfdbfe;
+  }
+
+  .speech-button {
+    background: #1e293b;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  }
+
+  .speech-button--compact {
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  }
+
+  .speech-button:hover {
+    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.55);
+  }
+
+  .speech-button__pronunciation {
+    color: #cbd5f5;
+  }
+
+  .speech-button__english {
+    color: #94a3b8;
+  }
+
+  .empty-state {
     color: #94a3b8;
   }
 }


### PR DESCRIPTION
## Summary
- retitle the page for targeted vocabulary practice and swap in a dedicated container for the new layout
- rebuild the client script and styles to present grouped vocabulary rows with pronunciation playback and example phrases
- replace the phrases data with focused greetings and article vocabulary plus sample sentences that use each form

## Testing
- python -m json.tool phrases.json

------
https://chatgpt.com/codex/tasks/task_e_68d04f6b9030832c8fedd93f02b2c6af