### PR TITLE
Add PR preview deployment workflow

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy Preview
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pages-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true
+
+      - name: Comment preview link
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Preview ready for commit `${{ github.event.pull_request.head.sha }}`
+
+            🔗 **Preview URL:** ${{ steps.deploy.outputs.page_url }}
+          body-includes: 'Preview URL:'

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ This site is static and can be hosted on GitHub Pages:
 1. Push the repository to GitHub.
 2. In the repository settings, enable GitHub Pages and select the `main` branch (or the branch that should be published).
 3. Wait for the deployment to finish and access the published URL provided by GitHub.
+
+## Pull request previews
+
+Each pull request automatically gets a preview deployment. The CI workflow builds the static site, publishes it to a GitHub Pages
+preview environment for that revision, and leaves a comment on the PR with a link to the live preview. This makes it easy to review
+changes to the site in a browser before merging.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the static site for each PR and deploys it to a GitHub Pages preview environment
- post the preview URL back to the pull request using a bot comment so reviewers can open the live site
- document the new preview flow in the README for contributors

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d057b39f2c832c9d5921bac4ebe1a3