### PR TITLE
Create targeted practice view for known Greek vocabulary

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Greek Travel Phrases</title>
+  <title>Targeted Greek Practice</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <main>
-    <h1>Greek Travel Phrases</h1>
-    <p class="description">Tap a phrase to hear the Greek pronunciation and see its meaning at a glance.</p>
+    <h1>Targeted Greek Practice</h1>
+    <p class="description">Focus on the greetings and helper words you already know. Tap a card to hear it in Greek and pair it with ready-made example sentences.</p>
     <p id="support-message" class="support-message" aria-live="polite"></p>
     <div id="phrase-groups" class="phrase-groups" aria-live="polite"></div>
   </main>

--- a/phrases.json
+++ b/phrases.json
@@ -1,251 +1,351 @@
 [
   {
-    "category": "Greetings & Essentials",
-    "description": "Key greetings and polite expressions for everyday encounters.",
-    "phrases": [
+    "category": "Greetings",
+    "description": "Practice the greetings you already know by pairing them with real-life situations.",
+    "rows": [
       {
-        "greek": "Γειά σου",
-        "pronunciation": "Ya sou",
-        "english": "Hello (informal)"
+        "title": "Yeia sou / Yeia sas",
+        "summary": "Switch between informal and formal hello depending on who you're greeting.",
+        "items": [
+          {
+            "greek": "Γεια σου",
+            "pronunciation": "Ya sou",
+            "english": "Hello (informal)"
+          },
+          {
+            "greek": "Γεια σας",
+            "pronunciation": "Ya sas",
+            "english": "Hello (formal / plural)"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Γεια σου, Μαρία!",
+            "pronunciation": "Ya sou, María!",
+            "english": "Hello, Maria!"
+          },
+          {
+            "greek": "Γεια σας, κύριε Παύλο.",
+            "pronunciation": "Ya sas, kýrie Pavlo.",
+            "english": "Hello, Mr. Pavlos."
+          }
+        ]
       },
       {
-        "greek": "Γειά σας",
-        "pronunciation": "Ya sas",
-        "english": "Hello (formal / plural)"
+        "title": "Kalimera / kalispera / kalinikhta",
+        "summary": "Match your greeting with the time of day.",
+        "items": [
+          {
+            "greek": "Καλημέρα",
+            "pronunciation": "Kaliméra",
+            "english": "Good morning"
+          },
+          {
+            "greek": "Καλησπέρα",
+            "pronunciation": "Kalispera",
+            "english": "Good evening"
+          },
+          {
+            "greek": "Καληνύχτα",
+            "pronunciation": "Kaliníkhta",
+            "english": "Good night"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Καλημέρα! Τι κάνεις;",
+            "pronunciation": "Kaliméra! Ti kánis?",
+            "english": "Good morning! How are you?"
+          },
+          {
+            "greek": "Καλησπέρα σε όλους.",
+            "pronunciation": "Kalispera se ólous.",
+            "english": "Good evening, everyone."
+          },
+          {
+            "greek": "Καληνύχτα και όνειρα γλυκά.",
+            "pronunciation": "Kaliníkhta kai ónira glyká.",
+            "english": "Good night and sweet dreams."
+          }
+        ]
       },
       {
-        "greek": "Καλημέρα",
-        "pronunciation": "Kaliméra",
-        "english": "Good morning"
+        "title": "Ti kanete / kala",
+        "summary": "Ask how someone is doing and respond with confidence.",
+        "items": [
+          {
+            "greek": "Τι κάνετε;",
+            "pronunciation": "Ti kánete?",
+            "english": "How are you? (formal)"
+          },
+          {
+            "greek": "Καλά",
+            "pronunciation": "Kalá",
+            "english": "Well / fine"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Τι κάνετε σήμερα;",
+            "pronunciation": "Ti kánete símera?",
+            "english": "How are you today?"
+          },
+          {
+            "greek": "Είμαι καλά, ευχαριστώ.",
+            "pronunciation": "Íme kalá, efharistó.",
+            "english": "I'm well, thank you."
+          },
+          {
+            "greek": "Καλά, κι εσείς;",
+            "pronunciation": "Kalá, ki esís?",
+            "english": "I'm well, and you?"
+          }
+        ]
       },
       {
-        "greek": "Καλησπέρα",
-        "pronunciation": "Kalispera",
-        "english": "Good evening"
+        "title": "Parakalo / Efharisto",
+        "summary": "Balance politeness and gratitude in everyday exchanges.",
+        "items": [
+          {
+            "greek": "Παρακαλώ",
+            "pronunciation": "Parakaló",
+            "english": "Please / you're welcome"
+          },
+          {
+            "greek": "Ευχαριστώ",
+            "pronunciation": "Efharistó",
+            "english": "Thank you"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ένα νερό, παρακαλώ.",
+            "pronunciation": "Éna neró, parakaló.",
+            "english": "One water, please."
+          },
+          {
+            "greek": "Ευχαριστώ για τη βοήθεια.",
+            "pronunciation": "Efharistó gia ti voítheia.",
+            "english": "Thank you for the help."
+          },
+          {
+            "greek": "Παρακαλώ, περάστε.",
+            "pronunciation": "Parakaló, peráste.",
+            "english": "Please, come in."
+          }
+        ]
       },
       {
-        "greek": "Καληνύχτα",
-        "pronunciation": "Kaliníkhta",
-        "english": "Good night"
-      },
-      {
-        "greek": "Τι κάνετε;",
-        "pronunciation": "Ti kánete?",
-        "english": "How are you?"
-      },
-      {
-        "greek": "Καλά, ευχαριστώ.",
-        "pronunciation": "Kalá, efharistó.",
-        "english": "I'm well, thank you."
-      },
-      {
-        "greek": "Παρακαλώ",
-        "pronunciation": "Parakaló",
-        "english": "Please / You're welcome"
-      },
-      {
-        "greek": "Ευχαριστώ",
-        "pronunciation": "Efharistó",
-        "english": "Thank you"
-      },
-      {
-        "greek": "Συγγνώμη",
-        "pronunciation": "Signómi",
-        "english": "Excuse me / Sorry"
-      },
-      {
-        "greek": "Ναι",
-        "pronunciation": "Ne",
-        "english": "Yes"
-      },
-      {
-        "greek": "Όχι",
-        "pronunciation": "Óhi",
-        "english": "No"
+        "title": "Signomi",
+        "summary": "Apologize or get someone's attention politely.",
+        "items": [
+          {
+            "greek": "Συγγνώμη",
+            "pronunciation": "Signómi",
+            "english": "Sorry / excuse me"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Συγγνώμη για την καθυστέρηση.",
+            "pronunciation": "Signómi gia tin kathystérisi.",
+            "english": "Sorry for the delay."
+          },
+          {
+            "greek": "Συγγνώμη, μπορώ να περάσω;",
+            "pronunciation": "Signómi, boró na peráso?",
+            "english": "Excuse me, may I pass?"
+          },
+          {
+            "greek": "Συγγνώμη, δεν το είδα.",
+            "pronunciation": "Signómi, den to ída.",
+            "english": "Sorry, I didn't see it."
+          }
+        ]
       }
     ]
   },
   {
-    "category": "Getting Around",
-    "description": "Directions and travel phrases to help you navigate streets and transport.",
-    "phrases": [
+    "category": "Articles",
+    "description": "Blend your helper words with short sentences to reinforce how you already use them.",
+    "rows": [
       {
-        "greek": "Πού είναι το ξενοδοχείο;",
-        "pronunciation": "Pou íne to xenodohío?",
-        "english": "Where is the hotel?"
+        "title": "Nai / oxi (yes/no)",
+        "summary": "Answer clearly with yes or no.",
+        "items": [
+          {
+            "greek": "Ναι",
+            "pronunciation": "Ne",
+            "english": "Yes"
+          },
+          {
+            "greek": "Όχι",
+            "pronunciation": "Óhi",
+            "english": "No"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ναι, θέλω καφέ.",
+            "pronunciation": "Ne, thélo kafé.",
+            "english": "Yes, I want coffee."
+          },
+          {
+            "greek": "Όχι, ευχαριστώ.",
+            "pronunciation": "Óhi, efharistó.",
+            "english": "No, thank you."
+          },
+          {
+            "greek": "Ναι ή όχι;",
+            "pronunciation": "Ne í óhi?",
+            "english": "Yes or no?"
+          }
+        ]
       },
       {
-        "greek": "Πού είναι η στάση λεωφορείου;",
-        "pronunciation": "Pou íne i stási leoforíu?",
-        "english": "Where is the bus stop?"
+        "title": "Einai (is)",
+        "summary": "Point out what something or someone is.",
+        "items": [
+          {
+            "greek": "Είναι",
+            "pronunciation": "Íne",
+            "english": "Is / are"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Αυτή είναι η φίλη μου.",
+            "pronunciation": "Aftí íne i fíli mou.",
+            "english": "This is my friend."
+          },
+          {
+            "greek": "Το μουσείο είναι ανοιχτό;",
+            "pronunciation": "To mousío íne anikhtó?",
+            "english": "Is the museum open?"
+          },
+          {
+            "greek": "Η θάλασσα είναι όμορφη σήμερα.",
+            "pronunciation": "I thálassa íne ómorfi símera.",
+            "english": "The sea is beautiful today."
+          }
+        ]
       },
       {
-        "greek": "Θα ήθελα ένα ταξί, παρακαλώ.",
-        "pronunciation": "Tha íthela éna taxí, parakaló.",
-        "english": "I'd like a taxi, please."
+        "title": "Kanei (makes)",
+        "summary": "Talk about what something does or how much it costs.",
+        "items": [
+          {
+            "greek": "Κάνει",
+            "pronunciation": "Káni",
+            "english": "Does / makes"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Τι κάνει η Μαρία;",
+            "pronunciation": "Ti káni i María?",
+            "english": "What is Maria doing?"
+          },
+          {
+            "greek": "Η σούπα κάνει δέκα ευρώ.",
+            "pronunciation": "I soúpa káni déka evró.",
+            "english": "The soup costs ten euros."
+          },
+          {
+            "greek": "Κάνει ζέστη σήμερα.",
+            "pronunciation": "Káni zésti símera.",
+            "english": "It's hot today."
+          }
+        ]
       },
       {
-        "greek": "Μπορείτε να με πάτε στο αεροδρόμιο;",
-        "pronunciation": "Boríte na me páte sto aerodrómio?",
-        "english": "Can you take me to the airport?"
+        "title": "Sto (at)",
+        "summary": "Place people and things where they belong.",
+        "items": [
+          {
+            "greek": "Στο",
+            "pronunciation": "Sto",
+            "english": "At the / in the"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Είμαι στο ξενοδοχείο.",
+            "pronunciation": "Íme sto xenodohío.",
+            "english": "I am at the hotel."
+          },
+          {
+            "greek": "Θα σε δω στο μουσείο.",
+            "pronunciation": "Tha se do sto mousío.",
+            "english": "I'll see you at the museum."
+          },
+          {
+            "greek": "Το ποδήλατο είναι στο σπίτι.",
+            "pronunciation": "To podílato íne sto spíti.",
+            "english": "The bicycle is at home."
+          }
+        ]
       },
       {
-        "greek": "Πόση ώρα διαρκεί;",
-        "pronunciation": "Pósi óra diarkí?",
-        "english": "How long does it take?"
+        "title": "Tha íthela (I would like)",
+        "summary": "Politely ask for what you want.",
+        "items": [
+          {
+            "greek": "Θα ήθελα",
+            "pronunciation": "Tha íthela",
+            "english": "I would like"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Θα ήθελα έναν χυμό.",
+            "pronunciation": "Tha íthela énan chimó.",
+            "english": "I would like a juice."
+          },
+          {
+            "greek": "Θα ήθελα να πληρώσω τώρα.",
+            "pronunciation": "Tha íthela na pliróso tóra.",
+            "english": "I would like to pay now."
+          },
+          {
+            "greek": "Θα ήθελα πληροφορίες.",
+            "pronunciation": "Tha íthela pliroforíes.",
+            "english": "I would like some information."
+          }
+        ]
       },
       {
-        "greek": "Μπορείτε να το γράψετε;",
-        "pronunciation": "Boríte na to grápsete?",
-        "english": "Could you write it down?"
-      },
-      {
-        "greek": "Χάθηκα.",
-        "pronunciation": "Háthika.",
-        "english": "I'm lost."
-      },
-      {
-        "greek": "Μπορείτε να μου δείξετε στον χάρτη;",
-        "pronunciation": "Boríte na mou díxete ston hárti?",
-        "english": "Can you show me on the map?"
-      }
-    ]
-  },
-  {
-    "category": "Dining & Food",
-    "description": "Order confidently and share dietary needs while eating out.",
-    "phrases": [
-      {
-        "greek": "Ένα τραπέζι για δύο, παρακαλώ.",
-        "pronunciation": "Éna trapézi gia dýo, parakaló.",
-        "english": "A table for two, please."
-      },
-      {
-        "greek": "Θα ήθελα το μενού, παρακαλώ.",
-        "pronunciation": "Tha íthela to menoú, parakaló.",
-        "english": "I'd like the menu, please."
-      },
-      {
-        "greek": "Τι προτείνετε;",
-        "pronunciation": "Ti proteínete?",
-        "english": "What do you recommend?"
-      },
-      {
-        "greek": "Το λογαριασμό, παρακαλώ.",
-        "pronunciation": "To logariasmó, parakaló.",
-        "english": "The bill, please."
-      },
-      {
-        "greek": "Νερό, παρακαλώ.",
-        "pronunciation": "Neró, parakaló.",
-        "english": "Water, please."
-      },
-      {
-        "greek": "Είμαι χορτοφάγος.",
-        "pronunciation": "Íme hortofágos.",
-        "english": "I'm vegetarian."
-      },
-      {
-        "greek": "Έχω αλλεργία στα φιστίκια.",
-        "pronunciation": "Ého allergía sta fistíkia.",
-        "english": "I'm allergic to peanuts."
-      },
-      {
-        "greek": "Χωρίς πάγο, παρακαλώ.",
-        "pronunciation": "Horís págo, parakaló.",
-        "english": "No ice, please."
-      }
-    ]
-  },
-  {
-    "category": "Shopping & Money",
-    "description": "Useful questions for prices, payments, and finding the right item.",
-    "phrases": [
-      {
-        "greek": "Πόσο κάνει αυτό;",
-        "pronunciation": "Póso káni aftó?",
-        "english": "How much is this?"
-      },
-      {
-        "greek": "Μπορείτε να μου κάνετε μια καλύτερη τιμή;",
-        "pronunciation": "Boríte na mou kánete mia kalýteri timí?",
-        "english": "Can you give me a better price?"
-      },
-      {
-        "greek": "Δέχεστε κάρτα;",
-        "pronunciation": "Déheste kárta?",
-        "english": "Do you accept card?"
-      },
-      {
-        "greek": "Μπορώ να πληρώσω με μετρητά;",
-        "pronunciation": "Boró na pliróso me metritá?",
-        "english": "Can I pay with cash?"
-      },
-      {
-        "greek": "Θα το πάρω.",
-        "pronunciation": "Tha to páro.",
-        "english": "I'll take it."
-      },
-      {
-        "greek": "Ψάχνω για ένα σουβενίρ.",
-        "pronunciation": "Psáhno gia éna souvenir.",
-        "english": "I'm looking for a souvenir."
-      },
-      {
-        "greek": "Έχετε άλλο χρώμα;",
-        "pronunciation": "Éhete állo hróma?",
-        "english": "Do you have another color?"
-      },
-      {
-        "greek": "Μπορώ να το δοκιμάσω;",
-        "pronunciation": "Boró na to dokimáso?",
-        "english": "Can I try it on?"
-      }
-    ]
-  },
-  {
-    "category": "Emergencies & Health",
-    "description": "Stay safe with phrases for urgent situations and communication help.",
-    "phrases": [
-      {
-        "greek": "Βοήθεια!",
-        "pronunciation": "Voítheia!",
-        "english": "Help!"
-      },
-      {
-        "greek": "Καλέστε ασθενοφόρο!",
-        "pronunciation": "Kaléste asthenofóro!",
-        "english": "Call an ambulance!"
-      },
-      {
-        "greek": "Χρειάζομαι γιατρό.",
-        "pronunciation": "Hriazóme giatró.",
-        "english": "I need a doctor."
-      },
-      {
-        "greek": "Πού είναι το νοσοκομείο;",
-        "pronunciation": "Pou íne to nosokomío?",
-        "english": "Where is the hospital?"
-      },
-      {
-        "greek": "Έχασα το διαβατήριό μου.",
-        "pronunciation": "Éhasa to diavatírio mou.",
-        "english": "I lost my passport."
-      },
-      {
-        "greek": "Υπάρχει φαρμακείο κοντά;",
-        "pronunciation": "Ipárhi farmakeío kondá?",
-        "english": "Is there a pharmacy nearby?"
-      },
-      {
-        "greek": "Μπορείτε να μιλήσετε πιο αργά;",
-        "pronunciation": "Boríte na milísete pio argá?",
-        "english": "Can you speak more slowly?"
-      },
-      {
-        "greek": "Δεν μιλάω πολύ καλά ελληνικά.",
-        "pronunciation": "Den miláo polí kalá elliniká.",
-        "english": "I don't speak Greek very well."
+        "title": "O antras / i yunaika",
+        "summary": "Keep the words for man and woman fresh.",
+        "items": [
+          {
+            "greek": "Ο άντρας",
+            "pronunciation": "O ántras",
+            "english": "The man"
+          },
+          {
+            "greek": "Η γυναίκα",
+            "pronunciation": "I yinéka",
+            "english": "The woman"
+          }
+        ],
+        "examples": [
+          {
+            "greek": "Ο άντρας είναι δάσκαλος.",
+            "pronunciation": "O ántras íne dáskalos.",
+            "english": "The man is a teacher."
+          },
+          {
+            "greek": "Η γυναίκα είναι στο γραφείο.",
+            "pronunciation": "I yinéka íne sto grafío.",
+            "english": "The woman is at the office."
+          },
+          {
+            "greek": "Ο άντρας και η γυναίκα πίνουν καφέ.",
+            "pronunciation": "O ántras kai i yinéka pínoún kafé.",
+            "english": "The man and the woman are drinking coffee."
+          }
+        ]
       }
     ]
   }

--- a/script.js
+++ b/script.js
@@ -37,42 +37,115 @@ function speakPhrase(phrase, button) {
   window.speechSynthesis.speak(utterance);
 }
 
+function sanitizePracticeRow(row) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const items = Array.isArray(row.items)
+    ? row.items.filter(
+        item => item && typeof item === 'object' && item.greek && item.english
+      )
+    : [];
+
+  if (!items.length) {
+    return null;
+  }
+
+  const sanitizedRow = {
+    ...row,
+    items
+  };
+
+  if (Array.isArray(row.examples)) {
+    const examples = row.examples.filter(
+      example =>
+        example && typeof example === 'object' && example.greek && example.english
+    );
+    if (examples.length) {
+      sanitizedRow.examples = examples;
+    } else {
+      delete sanitizedRow.examples;
+    }
+  }
+
+  if (typeof row.examplesLabel === 'string') {
+    const label = row.examplesLabel.trim();
+    if (label) {
+      sanitizedRow.examplesLabel = label;
+    } else {
+      delete sanitizedRow.examplesLabel;
+    }
+  }
+
+  if (typeof row.title === 'string') {
+    const title = row.title.trim();
+    if (title) {
+      sanitizedRow.title = title;
+    } else {
+      delete sanitizedRow.title;
+    }
+  }
+
+  if (typeof row.summary === 'string') {
+    const summary = row.summary.trim();
+    if (summary) {
+      sanitizedRow.summary = summary;
+    } else {
+      delete sanitizedRow.summary;
+    }
+  }
+
+  return sanitizedRow;
+}
+
+function sanitizeGroup(group) {
+  if (!group || typeof group !== 'object') {
+    return null;
+  }
+
+  const sanitized = { ...group };
+  let hasContent = false;
+
+  if (Array.isArray(group.phrases)) {
+    const phrases = group.phrases.filter(
+      phrase => phrase && typeof phrase === 'object' && phrase.greek && phrase.english
+    );
+    if (phrases.length) {
+      sanitized.phrases = phrases;
+      hasContent = true;
+    } else {
+      delete sanitized.phrases;
+    }
+  }
+
+  if (Array.isArray(group.rows)) {
+    const rows = group.rows.map(sanitizePracticeRow).filter(Boolean);
+    if (rows.length) {
+      sanitized.rows = rows;
+      hasContent = true;
+    } else {
+      delete sanitized.rows;
+    }
+  }
+
+  if (!hasContent) {
+    return null;
+  }
+
+  return sanitized;
+}
+
 function normalizeGroups(data) {
   if (!data) {
     return [];
   }
 
-  if (Array.isArray(data)) {
-    const looksLikeGroups = data.every(
-      item => item && typeof item === 'object' && Array.isArray(item.phrases)
-    );
-
-    if (looksLikeGroups) {
-      return data;
-    }
-
-    const phrases = data.filter(item => item && typeof item === 'object');
-    if (!phrases.length) {
-      return [];
-    }
-
-    return [
-      {
-        category: 'Common phrases',
-        phrases
-      }
-    ];
-  }
-
-  if (typeof data === 'object' && Array.isArray(data.phrases)) {
-    return [data];
-  }
-
-  return [];
+  const source = Array.isArray(data) ? data : [data];
+  return source.map(sanitizeGroup).filter(Boolean);
 }
 
-function createPhraseListItem(phrase) {
-  const li = document.createElement('li');
+function createPhraseButton(phrase) {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'phrase-button';
@@ -81,25 +154,113 @@ function createPhraseListItem(phrase) {
   greek.className = 'phrase-text';
   greek.lang = 'el';
   greek.textContent = phrase.greek;
-
-  const pronunciation = document.createElement('span');
-  pronunciation.className = 'phrase-pronunciation';
-  if (phrase.pronunciation) {
-    pronunciation.textContent = phrase.pronunciation;
-  }
-
-  const english = document.createElement('span');
-  english.className = 'phrase-english';
-  english.textContent = phrase.english;
-
   button.append(greek);
+
   if (phrase.pronunciation) {
+    const pronunciation = document.createElement('span');
+    pronunciation.className = 'phrase-pronunciation';
+    pronunciation.textContent = phrase.pronunciation;
     button.append(pronunciation);
   }
-  button.append(english);
+
+  if (phrase.english) {
+    const english = document.createElement('span');
+    english.className = 'phrase-english';
+    english.textContent = phrase.english;
+    button.append(english);
+  }
 
   button.addEventListener('click', () => speakPhrase(phrase, button));
-  li.append(button);
+  return button;
+}
+
+function createPhraseListItem(phrase) {
+  const li = document.createElement('li');
+  li.append(createPhraseButton(phrase));
+  return li;
+}
+
+function createPracticeRow(row) {
+  if (!row || !Array.isArray(row.items) || !row.items.length) {
+    return null;
+  }
+
+  const li = document.createElement('li');
+  li.className = 'practice-row';
+
+  if (row.title) {
+    const title = document.createElement('h3');
+    title.className = 'practice-row-title';
+    title.textContent = row.title;
+    li.append(title);
+  }
+
+  if (row.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'practice-row-summary';
+    summary.textContent = row.summary;
+    li.append(summary);
+  }
+
+  const vocab = document.createElement('div');
+  vocab.className = 'practice-row-vocabulary';
+  row.items.forEach(item => {
+    if (item && typeof item === 'object' && item.greek && item.english) {
+      vocab.append(createPhraseButton(item));
+    }
+  });
+
+  if (!vocab.children.length) {
+    return null;
+  }
+
+  li.append(vocab);
+
+  if (Array.isArray(row.examples) && row.examples.length) {
+    const examplesWrapper = document.createElement('div');
+    examplesWrapper.className = 'practice-row-examples';
+
+    const label = document.createElement('p');
+    label.className = 'practice-row-examples-label';
+    label.textContent = row.examplesLabel || 'Example phrases';
+    examplesWrapper.append(label);
+
+    const list = document.createElement('ul');
+    list.className = 'practice-examples-list';
+
+    row.examples.forEach(example => {
+      if (example && typeof example === 'object' && example.greek && example.english) {
+        const item = document.createElement('li');
+        item.className = 'practice-example';
+
+        const greek = document.createElement('span');
+        greek.className = 'practice-example-greek';
+        greek.lang = 'el';
+        greek.textContent = example.greek;
+        item.append(greek);
+
+        if (example.pronunciation) {
+          const pronunciation = document.createElement('span');
+          pronunciation.className = 'practice-example-pronunciation';
+          pronunciation.textContent = example.pronunciation;
+          item.append(pronunciation);
+        }
+
+        const english = document.createElement('span');
+        english.className = 'practice-example-english';
+        english.textContent = example.english;
+        item.append(english);
+
+        list.append(item);
+      }
+    });
+
+    if (list.children.length) {
+      examplesWrapper.append(list);
+      li.append(examplesWrapper);
+    }
+  }
+
   return li;
 }
 
@@ -109,9 +270,7 @@ function renderPhrases(data) {
   }
 
   groupsContainer.textContent = '';
-  const groups = normalizeGroups(data).filter(
-    group => Array.isArray(group.phrases) && group.phrases.length
-  );
+  const groups = normalizeGroups(data);
 
   if (!groups.length) {
     const emptyMessage = document.createElement('p');
@@ -149,7 +308,9 @@ function renderPhrases(data) {
     icon.className = 'phrase-group-toggle-icon';
     icon.setAttribute('aria-hidden', 'true');
     icon.innerHTML =
-      '<svg viewBox="0 0 12 8" width="12" height="8" focusable="false" aria-hidden="true"><path d="M1 1l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      '<svg viewBox="0 0 12 8" width="12" height="8" focusable="false" aria-hidden="true">' +
+      '<path d="M1 1l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+      '</svg>';
     toggleButton.append(icon);
 
     heading.append(toggleButton);
@@ -159,50 +320,77 @@ function renderPhrases(data) {
     content.className = 'phrase-group-content';
     content.id = contentId;
 
+    let hasContent = false;
+
     if (group.description) {
       const description = document.createElement('p');
       description.className = 'phrase-group-description';
       description.textContent = group.description;
       content.append(description);
+      hasContent = true;
     }
 
-    const list = document.createElement('ul');
-    list.className = 'phrases';
-    group.phrases.forEach(phrase => {
-      if (phrase && typeof phrase === 'object' && phrase.greek && phrase.english) {
-        list.append(createPhraseListItem(phrase));
-      }
-    });
-
-    if (list.children.length) {
-      content.append(list);
-      section.append(content);
-
-      const setCollapsedState = collapsed => {
-        section.classList.toggle('is-collapsed', collapsed);
-        toggleButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-        if (collapsed) {
-          content.hidden = true;
-          content.setAttribute('aria-hidden', 'true');
-          content.style.display = 'none';
-        } else {
-          content.hidden = false;
-          content.removeAttribute('hidden');
-          content.removeAttribute('aria-hidden');
-          content.style.display = '';
+    if (Array.isArray(group.rows) && group.rows.length) {
+      const rowsList = document.createElement('ul');
+      rowsList.className = 'practice-rows';
+      group.rows.forEach(row => {
+        const rowElement = createPracticeRow(row);
+        if (rowElement) {
+          rowsList.append(rowElement);
         }
-      };
-
-      const startCollapsed = collapseOnMobile && groupIndex > 0;
-      setCollapsedState(startCollapsed);
-
-      toggleButton.addEventListener('click', () => {
-        const nextCollapsed = !section.classList.contains('is-collapsed');
-        setCollapsedState(nextCollapsed);
       });
 
-      groupsContainer.append(section);
+      if (rowsList.children.length) {
+        content.append(rowsList);
+        hasContent = true;
+      }
     }
+
+    if (Array.isArray(group.phrases) && group.phrases.length) {
+      const list = document.createElement('ul');
+      list.className = 'phrases';
+      group.phrases.forEach(phrase => {
+        if (phrase && typeof phrase === 'object' && phrase.greek && phrase.english) {
+          list.append(createPhraseListItem(phrase));
+        }
+      });
+
+      if (list.children.length) {
+        content.append(list);
+        hasContent = true;
+      }
+    }
+
+    if (!hasContent) {
+      return;
+    }
+
+    section.append(content);
+
+    const setCollapsedState = collapsed => {
+      section.classList.toggle('is-collapsed', collapsed);
+      toggleButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      if (collapsed) {
+        content.hidden = true;
+        content.setAttribute('aria-hidden', 'true');
+        content.style.display = 'none';
+      } else {
+        content.hidden = false;
+        content.removeAttribute('hidden');
+        content.removeAttribute('aria-hidden');
+        content.style.display = '';
+      }
+    };
+
+    const startCollapsed = collapseOnMobile && groupIndex > 0;
+    setCollapsedState(startCollapsed);
+
+    toggleButton.addEventListener('click', () => {
+      const nextCollapsed = !section.classList.contains('is-collapsed');
+      setCollapsedState(nextCollapsed);
+    });
+
+    groupsContainer.append(section);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@ body {
 
 main {
   width: 100%;
-  max-width: 640px;
+  max-width: 760px;
 }
 
 h1 {
@@ -163,6 +163,91 @@ h1 {
   gap: clamp(0.65rem, 2.5vw, 0.9rem);
 }
 
+.practice-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.85rem, 2.5vw, 1.2rem);
+}
+
+.practice-row {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.4rem);
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.1rem);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.practice-row-title {
+  margin: 0;
+  font-size: clamp(1.05rem, 2vw + 0.9rem, 1.35rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.practice-row-summary {
+  margin: 0;
+  color: #52606d;
+  line-height: 1.5;
+}
+
+.practice-row-vocabulary {
+  display: grid;
+  gap: clamp(0.6rem, 2vw, 0.9rem);
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.practice-row-vocabulary .phrase-button {
+  height: 100%;
+}
+
+.practice-row-examples {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: clamp(0.75rem, 2vw, 1rem);
+  display: grid;
+  gap: clamp(0.5rem, 1.8vw, 0.75rem);
+}
+
+.practice-row-examples-label {
+  margin: 0;
+  font-weight: 600;
+  font-size: clamp(0.85rem, 1.8vw, 0.95rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #52606d;
+}
+
+.practice-examples-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: clamp(0.55rem, 1.6vw, 0.75rem);
+}
+
+.practice-example {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.practice-example-greek {
+  font-weight: 600;
+}
+
+.practice-example-pronunciation {
+  color: #8291a5;
+  font-size: clamp(0.9rem, 2vw, 0.95rem);
+}
+
+.practice-example-english {
+  color: #52606d;
+  font-size: clamp(0.92rem, 2vw, 1rem);
+}
+
 .empty-state {
   margin: 0;
   text-align: center;
@@ -297,6 +382,32 @@ h1 {
 
   .phrase-english {
     color: #94a3b8;
+  }
+
+  .practice-row {
+    background: rgba(30, 41, 59, 0.78);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.5);
+  }
+
+  .practice-row-summary {
+    color: #94a3b8;
+  }
+
+  .practice-row-examples {
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .practice-row-examples-label {
+    color: #cbd5f5;
+  }
+
+  .practice-example-pronunciation {
+    color: #cbd5f5;
+  }
+
+  .practice-example-english {
+    color: #cbd5f5;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the static travel phrase list with greeting and article practice rows that include grouped vocabulary and example sentences
- extend the rendering logic to support the new row-based data, reusable speech buttons, and example blocks
- refresh the page copy and styles to highlight the targeted practice layout

## Testing
- python -m json.tool phrases.json

------
https://chatgpt.com/codex/tasks/task_e_68d04f6b9030832c8fedd93f02b2c6af