### PR TITLE
Add environment configuration for preview deploy workflow

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout pull request
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- configure the preview deployment job to use the required `github-pages` environment
- expose the deployment URL to the environment so previews surface the correct link

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d05dba2e8c832c8bb9d37c5a04174b