### PR TITLE
Redesign phrase practice UI with search and collapsible sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A static, mobile-friendly website listing common Greek phrases helpful for trave
 
 ## Features
 
-- Responsive layout that works well on phones and tablets
+- Responsive layout that keeps the phrase cards easy to read on phones and tablets
+- Quick search bar to filter phrases across every category as you type
+- Collapsible practice sections so you can focus on a single topic at a time
 - Phrases are configured in [`phrases.json`](phrases.json) and loaded dynamically
 - Pronunciation playback uses the Web Speech API, so no audio files are required
 - Optional transliteration field to help with practicing pronunciation

--- a/index.html
+++ b/index.html
@@ -2,15 +2,56 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Greek Vocabulary Practice</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Greek Phrase Coach</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <main>
-    <h1>Targeted Greek Vocabulary Practice</h1>
-    <p class="description">Review the words you already know, hear their pronunciation, and see them in action inside short example phrases.</p>
-    <p id="support-message" class="support-message" aria-live="polite"></p>
+  <main class="page">
+    <header class="page-hero" role="banner">
+      <div class="page-hero__content">
+        <p class="page-hero__eyebrow">Confidence builder</p>
+        <h1 class="page-hero__title">Greek Phrase Coach</h1>
+        <p class="page-hero__description">
+          Practice the phrases you already know, listen to the pronunciation, and see them used inside short, practical sentences.
+        </p>
+      </div>
+    </header>
+
+    <section class="page-controls" aria-label="Practice controls">
+      <div class="page-controls__search">
+        <label class="field-label" for="phrase-search">Search phrases</label>
+        <div class="search-field">
+          <span class="search-field__icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" focusable="false" role="presentation">
+              <path
+                d="M12.9 14.32a7 7 0 1 1 1.41-1.41l3.4 3.39a1 1 0 0 1-1.42 1.42zM8 13a5 5 0 1 0 0-10 5 5 0 0 0 0 10z"
+              />
+            </svg>
+          </span>
+          <input
+            id="phrase-search"
+            class="search-field__input"
+            type="search"
+            name="phrase-search"
+            placeholder="Search Greek or English words"
+            autocomplete="off"
+            enterkeyhint="search"
+            spellcheck="false"
+          />
+          <button type="button" id="clear-search" class="search-field__clear" aria-label="Clear search">
+            <span aria-hidden="true" class="search-field__clear-icon">&times;</span>
+            <span class="search-field__clear-text">Clear</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="status-messages">
+        <p id="results-message" class="status-message" aria-live="polite"></p>
+        <p id="support-message" class="status-message support-message" aria-live="polite"></p>
+      </div>
+    </section>
+
     <div id="practice-groups" class="practice-groups" aria-live="polite"></div>
   </main>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,24 +1,38 @@
 const groupsContainer = document.getElementById('practice-groups');
 const supportMessage = document.getElementById('support-message');
+const resultsMessage = document.getElementById('results-message');
+const searchField = document.getElementById('phrase-search');
+const clearSearchButton = document.getElementById('clear-search');
+
 const ttsSupported =
   'speechSynthesis' in window && typeof SpeechSynthesisUtterance !== 'undefined';
+const ttsNotice = 'Pronunciation playback is not available in this browser.';
 let selectedVoice = null;
 
 if (!ttsSupported && supportMessage) {
-  supportMessage.textContent =
-    'Pronunciation playback is not available in this browser.';
+  supportMessage.textContent = ttsNotice;
 }
+
+const sectionState = new Map();
+let sectionIdCounter = 0;
+let allSections = [];
+let totalRowCount = 0;
+let searchInitialized = false;
 
 function chooseVoice(preferredLang = 'el') {
   if (!ttsSupported) {
     return null;
   }
   const voices = window.speechSynthesis.getVoices();
-  const byLang = voices.find(
-    voice => voice.lang && voice.lang.toLowerCase().startsWith(preferredLang)
+  const normalizedPreferred = preferredLang.toLowerCase();
+  const exactMatch = voices.find(
+    voice => voice.lang && voice.lang.toLowerCase().startsWith(normalizedPreferred)
   );
-  return (
-    byLang || voices.find(voice => voice.lang && voice.lang.toLowerCase().includes('el')) || null
+  if (exactMatch) {
+    return exactMatch;
+  }
+  return voices.find(
+    voice => voice.lang && voice.lang.toLowerCase().includes('el')
   );
 }
 
@@ -26,47 +40,221 @@ function speakPhrase(phrase, button) {
   if (!ttsSupported || !phrase || !button) {
     return;
   }
+
   const utterance = new SpeechSynthesisUtterance(phrase.speech || phrase.greek);
   utterance.lang = phrase.lang || 'el-GR';
+
   if (!selectedVoice || !window.speechSynthesis.getVoices().includes(selectedVoice)) {
     selectedVoice = chooseVoice((phrase.lang || 'el').toLowerCase());
   }
+
   if (selectedVoice) {
     utterance.voice = selectedVoice;
   }
+
   utterance.rate = phrase.rate || 0.9;
   utterance.onstart = () => button.classList.add('is-speaking');
   const clearSpeakingClass = () => button.classList.remove('is-speaking');
   utterance.onend = clearSpeakingClass;
   utterance.onerror = clearSpeakingClass;
+
   window.speechSynthesis.cancel();
   window.speechSynthesis.speak(utterance);
 }
 
+function isValidPhrase(phrase) {
+  return (
+    phrase &&
+    typeof phrase === 'object' &&
+    typeof phrase.greek === 'string' &&
+    phrase.greek.trim() !== ''
+  );
+}
+
+function sanitizePhrase(phrase) {
+  if (!isValidPhrase(phrase)) {
+    return null;
+  }
+  const sanitized = { ...phrase };
+  sanitized.greek = phrase.greek.trim();
+  if (typeof phrase.pronunciation === 'string') {
+    sanitized.pronunciation = phrase.pronunciation.trim();
+  }
+  if (typeof phrase.english === 'string') {
+    sanitized.english = phrase.english.trim();
+  }
+  if (typeof phrase.speech === 'string') {
+    sanitized.speech = phrase.speech.trim();
+  }
+  if (typeof phrase.lang === 'string') {
+    sanitized.lang = phrase.lang.trim();
+  }
+  return sanitized;
+}
+
 function normalizeSections(data) {
-  if (!data) {
-    return [];
+  const sections = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray(data.rows)
+    ? [data]
+    : [];
+
+  return sections
+    .map((section, sectionIndex) => {
+      if (!section || typeof section !== 'object') {
+        return null;
+      }
+
+      const rows = Array.isArray(section.rows)
+        ? section.rows
+            .map((row, rowIndex) => {
+              if (!row || typeof row !== 'object') {
+                return null;
+              }
+
+              const variants = Array.isArray(row.variants)
+                ? row.variants.map(sanitizePhrase).filter(Boolean)
+                : [];
+              const examples = Array.isArray(row.examples)
+                ? row.examples.map(sanitizePhrase).filter(Boolean)
+                : [];
+
+              if (!variants.length && !examples.length) {
+                return null;
+              }
+
+              return {
+                ...row,
+                title:
+                  typeof row.title === 'string' && row.title.trim()
+                    ? row.title
+                    : '',
+                summary:
+                  typeof row.summary === 'string' ? row.summary : '',
+                variants,
+                examples,
+                __id: `section-${sectionIndex}-row-${rowIndex}`,
+              };
+            })
+            .filter(Boolean)
+        : [];
+
+      if (!rows.length) {
+        return null;
+      }
+
+      return {
+        ...section,
+        category:
+          typeof section.category === 'string' && section.category.trim()
+            ? section.category
+            : 'Practice set',
+        description:
+          typeof section.description === 'string' ? section.description : '',
+        rows,
+        __id: `section-${sectionIndex}`,
+      };
+    })
+    .filter(Boolean);
+}
+
+function countRows(sections) {
+  if (!Array.isArray(sections)) {
+    return 0;
+  }
+  return sections.reduce(
+    (total, section) =>
+      total + (Array.isArray(section.rows) ? section.rows.length : 0),
+    0
+  );
+}
+
+function normalizeSearchValue(value) {
+  if (value == null) {
+    return '';
+  }
+  const text = String(value).toLowerCase().trim();
+  try {
+    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  } catch (error) {
+    return text;
+  }
+}
+
+function rowMatches(row, normalizedQuery) {
+  if (!row || typeof row !== 'object') {
+    return false;
   }
 
-  if (Array.isArray(data)) {
-    return data.filter(
-      section =>
-        section &&
-        typeof section === 'object' &&
-        Array.isArray(section.rows) &&
-        section.rows.some(row => row && typeof row === 'object')
-    );
+  const values = [];
+  if (row.title) {
+    values.push(row.title);
+  }
+  if (row.summary) {
+    values.push(row.summary);
+  }
+  if (row.examplesHeading) {
+    values.push(row.examplesHeading);
   }
 
-  if (typeof data === 'object' && Array.isArray(data.rows)) {
-    return [data];
+  if (Array.isArray(row.variants)) {
+    row.variants.forEach(variant => {
+      if (variant.greek) {
+        values.push(variant.greek);
+      }
+      if (variant.pronunciation) {
+        values.push(variant.pronunciation);
+      }
+      if (variant.english) {
+        values.push(variant.english);
+      }
+      if (variant.speech) {
+        values.push(variant.speech);
+      }
+    });
   }
 
-  return [];
+  if (Array.isArray(row.examples)) {
+    row.examples.forEach(example => {
+      if (example.greek) {
+        values.push(example.greek);
+      }
+      if (example.pronunciation) {
+        values.push(example.pronunciation);
+      }
+      if (example.english) {
+        values.push(example.english);
+      }
+      if (example.speech) {
+        values.push(example.speech);
+      }
+    });
+  }
+
+  return values.some(value => normalizeSearchValue(value).includes(normalizedQuery));
+}
+
+function filterSections(sections, normalizedQuery) {
+  if (!normalizedQuery) {
+    return sections;
+  }
+
+  return sections
+    .map(section => {
+      const rows = Array.isArray(section.rows)
+        ? section.rows.filter(row => rowMatches(row, normalizedQuery))
+        : [];
+      if (!rows.length) {
+        return null;
+      }
+      return { ...section, rows };
+    })
+    .filter(Boolean);
 }
 
 function createSpeechButton(phrase, { compact = false } = {}) {
-  if (!phrase || typeof phrase !== 'object' || !phrase.greek) {
+  const sanitizedPhrase = sanitizePhrase(phrase);
+  if (!sanitizedPhrase) {
     return null;
   }
 
@@ -79,26 +267,53 @@ function createSpeechButton(phrase, { compact = false } = {}) {
 
   const greek = document.createElement('span');
   greek.className = 'speech-button__text';
-  greek.lang = phrase.lang || 'el';
-  greek.textContent = phrase.greek;
+  greek.lang = sanitizedPhrase.lang || 'el';
+  greek.textContent = sanitizedPhrase.greek;
   button.append(greek);
 
-  if (phrase.pronunciation) {
+  if (sanitizedPhrase.pronunciation) {
     const pronunciation = document.createElement('span');
     pronunciation.className = 'speech-button__pronunciation';
-    pronunciation.textContent = phrase.pronunciation;
+    pronunciation.textContent = sanitizedPhrase.pronunciation;
     button.append(pronunciation);
   }
 
-  if (phrase.english) {
+  if (sanitizedPhrase.english) {
     const english = document.createElement('span');
     english.className = 'speech-button__english';
-    english.textContent = phrase.english;
+    english.textContent = sanitizedPhrase.english;
     button.append(english);
   }
 
-  button.addEventListener('click', () => speakPhrase(phrase, button));
+  if (ttsSupported) {
+    const tooltipParts = [sanitizedPhrase.greek];
+    if (sanitizedPhrase.english) {
+      tooltipParts.push(sanitizedPhrase.english);
+    }
+    button.title = `Play pronunciation: ${tooltipParts.join(' — ')}`;
+    button.addEventListener('click', () => speakPhrase(sanitizedPhrase, button));
+  } else {
+    button.disabled = true;
+    button.classList.add('speech-button--disabled');
+    button.title = 'Speech playback is not supported in this browser.';
+  }
+
   return button;
+}
+
+function createChevronIcon() {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 16 16');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.classList.add('practice-section__icon');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute(
+    'd',
+    'M3.2 5.3a1 1 0 0 1 1.4 0L8 8.7l3.4-3.4a1 1 0 1 1 1.4 1.4l-4.1 4.1a1 1 0 0 1-1.4 0L3.2 6.7a1 1 0 0 1 0-1.4z'
+  );
+  path.setAttribute('fill', 'currentColor');
+  svg.append(path);
+  return svg;
 }
 
 function createPracticeRow(row) {
@@ -106,156 +321,351 @@ function createPracticeRow(row) {
     return null;
   }
 
-  const variants = Array.isArray(row.variants)
-    ? row.variants.filter(variant => variant && typeof variant === 'object')
-    : [];
-  const examples = Array.isArray(row.examples)
-    ? row.examples.filter(example => example && typeof example === 'object')
-    : [];
+  const variants = Array.isArray(row.variants) ? row.variants : [];
+  const examples = Array.isArray(row.examples) ? row.examples : [];
 
   if (!variants.length && !examples.length) {
     return null;
   }
 
-  const article = document.createElement('article');
-  article.className = 'practice-row';
+  const item = document.createElement('li');
+  item.className = 'practice-card';
 
-  const main = document.createElement('div');
-  main.className = 'practice-row-main';
+  const meta = document.createElement('div');
+  meta.className = 'practice-card__meta';
 
   const title = document.createElement('h3');
-  title.className = 'practice-row-title';
-  title.textContent =
-    row.title || (variants.length ? variants.map(item => item.greek).join(' / ') : 'Practice item');
-  main.append(title);
+  title.className = 'practice-card__title';
+  const fallbackTitle =
+    variants.length > 0
+      ? variants.map(variant => variant.greek).join(' / ')
+      : 'Practice item';
+  title.textContent = row.title || fallbackTitle;
+  meta.append(title);
 
   if (row.summary) {
     const summary = document.createElement('p');
-    summary.className = 'practice-row-summary';
+    summary.className = 'practice-card__summary';
     summary.textContent = row.summary;
-    main.append(summary);
+    meta.append(summary);
   }
 
+  item.append(meta);
+
+  const sectionsWrapper = document.createElement('div');
+  sectionsWrapper.className = 'practice-card__sections';
+
   if (variants.length) {
-    const variantsWrapper = document.createElement('div');
-    variantsWrapper.className = 'practice-row-variants';
+    const variantsGroup = document.createElement('div');
+    variantsGroup.className = 'practice-card__group';
+
+    if (row.variantsLabel !== false) {
+      const label = document.createElement('p');
+      label.className = 'practice-card__label';
+      label.textContent = row.variantsLabel || 'Focus phrases';
+      variantsGroup.append(label);
+    }
+
+    const variantsList = document.createElement('div');
+    variantsList.className = 'practice-card__variants';
     variants.forEach(variant => {
       const button = createSpeechButton(variant, { compact: true });
       if (button) {
-        variantsWrapper.append(button);
+        variantsList.append(button);
       }
     });
 
-    if (variantsWrapper.children.length) {
-      if (row.variantsLabel !== false) {
-        const label = document.createElement('p');
-        label.className = 'practice-row-label';
-        label.textContent = row.variantsLabel || 'Core forms';
-        main.append(label);
-      }
-      main.append(variantsWrapper);
+    if (variantsList.children.length) {
+      variantsGroup.append(variantsList);
+      sectionsWrapper.append(variantsGroup);
     }
   }
 
-  article.append(main);
-
   if (examples.length) {
+    const examplesGroup = document.createElement('div');
+    examplesGroup.className = 'practice-card__group practice-card__examples';
+
+    const heading = document.createElement('h4');
+    heading.className = 'practice-card__heading';
+    heading.textContent = row.examplesHeading || 'Example phrases';
+    examplesGroup.append(heading);
+
     const list = document.createElement('ul');
-    list.className = 'example-list';
+    list.className = 'practice-card__example-list';
+
     examples.forEach(example => {
       const button = createSpeechButton(example);
       if (button) {
-        const item = document.createElement('li');
-        item.append(button);
-        list.append(item);
+        const itemElement = document.createElement('li');
+        itemElement.append(button);
+        list.append(itemElement);
       }
     });
 
     if (list.children.length) {
-      const examplesWrapper = document.createElement('div');
-      examplesWrapper.className = 'practice-row-examples';
-
-      const heading = document.createElement('h4');
-      heading.className = 'practice-row-examples-heading';
-      heading.textContent = row.examplesHeading || 'Example phrases';
-      examplesWrapper.append(heading);
-      examplesWrapper.append(list);
-      article.append(examplesWrapper);
+      examplesGroup.append(list);
+      sectionsWrapper.append(examplesGroup);
     }
   }
 
-  return article;
+  if (sectionsWrapper.children.length) {
+    item.append(sectionsWrapper);
+  }
+
+  return item;
 }
 
-function renderPractice(data) {
+function createPracticeSection(sectionData, { forceExpand = false } = {}) {
+  if (!sectionData || !Array.isArray(sectionData.rows) || !sectionData.rows.length) {
+    return null;
+  }
+
+  const section = document.createElement('section');
+  section.className = 'practice-section';
+
+  const header = document.createElement('header');
+  header.className = 'practice-section__header';
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'practice-section__toggle';
+
+  const textWrapper = document.createElement('span');
+  textWrapper.className = 'practice-section__text';
+
+  const title = document.createElement('span');
+  title.className = 'practice-section__title';
+  title.textContent = sectionData.category || 'Practice set';
+  textWrapper.append(title);
+
+  if (sectionData.description) {
+    const description = document.createElement('span');
+    description.className = 'practice-section__description';
+    description.textContent = sectionData.description;
+    textWrapper.append(description);
+  }
+
+  const icon = createChevronIcon();
+
+  toggle.append(textWrapper);
+  toggle.append(icon);
+
+  const toggleId = `practice-toggle-${sectionIdCounter++}`;
+  const panelId = `${toggleId}-panel`;
+  toggle.id = toggleId;
+  toggle.setAttribute('aria-controls', panelId);
+
+  const savedState = sectionState.get(sectionData.__id);
+  const shouldExpand = forceExpand ? true : savedState ? savedState.expanded : true;
+  toggle.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
+
+  header.append(toggle);
+  section.append(header);
+
+  const panel = document.createElement('div');
+  panel.className = 'practice-section__panel';
+  panel.id = panelId;
+  panel.setAttribute('role', 'region');
+  panel.setAttribute('aria-labelledby', toggleId);
+  panel.hidden = !shouldExpand;
+
+  const list = document.createElement('ul');
+  list.className = 'practice-list';
+  sectionData.rows.forEach(row => {
+    const rowElement = createPracticeRow(row);
+    if (rowElement) {
+      list.append(rowElement);
+    }
+  });
+
+  if (!list.children.length) {
+    return null;
+  }
+
+  panel.append(list);
+  section.append(panel);
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    const next = !expanded;
+    toggle.setAttribute('aria-expanded', String(next));
+    panel.hidden = !next;
+    sectionState.set(sectionData.__id, { expanded: next });
+  });
+
+  return section;
+}
+
+function renderSections(sections, { forceExpand = false, emptyMessage } = {}) {
   if (!groupsContainer) {
     return;
   }
 
   groupsContainer.textContent = '';
-  const sections = normalizeSections(data);
+  sectionIdCounter = 0;
 
   sections.forEach(sectionData => {
-    const rows = Array.isArray(sectionData.rows)
-      ? sectionData.rows
-          .map(createPracticeRow)
-          .filter(rowElement => rowElement instanceof HTMLElement)
-      : [];
-
-    if (!rows.length) {
-      return;
+    const sectionElement = createPracticeSection(sectionData, { forceExpand });
+    if (sectionElement) {
+      groupsContainer.append(sectionElement);
     }
-
-    const section = document.createElement('section');
-    section.className = 'practice-section';
-
-    const header = document.createElement('header');
-    header.className = 'practice-section-header';
-
-    const heading = document.createElement('h2');
-    heading.className = 'practice-section-title';
-    heading.textContent = sectionData.category || 'Practice set';
-    header.append(heading);
-
-    if (sectionData.description) {
-      const description = document.createElement('p');
-      description.className = 'practice-section-description';
-      description.textContent = sectionData.description;
-      header.append(description);
-    }
-
-    section.append(header);
-
-    const rowsWrapper = document.createElement('div');
-    rowsWrapper.className = 'practice-rows';
-    rows.forEach(rowElement => rowsWrapper.append(rowElement));
-    section.append(rowsWrapper);
-    groupsContainer.append(section);
   });
 
   if (!groupsContainer.children.length) {
-    const emptyMessage = document.createElement('p');
-    emptyMessage.className = 'empty-state';
-    emptyMessage.textContent = 'No practice items are available right now.';
-    groupsContainer.append(emptyMessage);
+    const message = document.createElement('p');
+    message.className = 'empty-state';
+    message.textContent =
+      emptyMessage || 'No practice items are available right now.';
+    groupsContainer.append(message);
   }
 }
 
-fetch('phrases.json')
-  .then(response => {
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+function updateResultsMessage(filteredCount, totalCount, rawQuery) {
+  if (!resultsMessage) {
+    return;
+  }
+
+  const trimmedQuery = typeof rawQuery === 'string' ? rawQuery.trim() : '';
+
+  if (totalCount === 0) {
+    resultsMessage.textContent = filteredCount
+      ? `Showing ${filteredCount} ${filteredCount === 1 ? 'phrase' : 'phrases'}.`
+      : 'No practice phrases are available yet.';
+    return;
+  }
+
+  if (trimmedQuery) {
+    if (filteredCount) {
+      const noun = filteredCount === 1 ? 'phrase' : 'phrases';
+      resultsMessage.textContent = `Showing ${filteredCount} ${noun} matching “${trimmedQuery}”.`;
+    } else {
+      resultsMessage.textContent = `No phrases match “${trimmedQuery}”.`;
     }
-    return response.json();
-  })
-  .then(renderPractice)
-  .catch(error => {
-    console.error('Failed to load practice data', error);
-    if (supportMessage) {
-      supportMessage.textContent =
-        'Unable to load the practice list. Please try again later.';
+    return;
+  }
+
+  const noun = totalCount === 1 ? 'phrase' : 'phrases';
+  resultsMessage.textContent = `Showing all ${totalCount} ${noun}.`;
+}
+
+function updateClearButtonVisibility() {
+  if (!clearSearchButton || !searchField) {
+    return;
+  }
+  const hasValue = Boolean(searchField.value);
+  clearSearchButton.hidden = !hasValue;
+}
+
+function applyFilters() {
+  const rawQuery = searchField ? searchField.value : '';
+  const normalizedQuery = normalizeSearchValue(rawQuery);
+  const hasQuery = Boolean(normalizedQuery);
+
+  const filteredSections = hasQuery
+    ? filterSections(allSections, normalizedQuery)
+    : allSections;
+
+  const options = {};
+  if (hasQuery) {
+    options.forceExpand = true;
+    if (!filteredSections.length) {
+      options.emptyMessage = rawQuery && rawQuery.trim()
+        ? `No phrases match “${rawQuery.trim()}”.`
+        : 'No phrases match your search.';
     }
-  });
+  }
+
+  renderSections(filteredSections, options);
+  const filteredCount = countRows(filteredSections);
+  updateResultsMessage(filteredCount, totalRowCount, rawQuery);
+  updateClearButtonVisibility();
+}
+
+function setupSearch() {
+  if (searchInitialized || !searchField) {
+    updateClearButtonVisibility();
+    return;
+  }
+
+  searchInitialized = true;
+  const handleInput = () => {
+    applyFilters();
+  };
+
+  searchField.addEventListener('input', handleInput);
+  searchField.addEventListener('search', handleInput);
+
+  if (clearSearchButton) {
+    clearSearchButton.addEventListener('click', () => {
+      searchField.value = '';
+      searchField.focus();
+      applyFilters();
+    });
+  }
+
+  updateClearButtonVisibility();
+}
+
+function handlePracticeData(data) {
+  allSections = normalizeSections(data);
+  totalRowCount = countRows(allSections);
+  sectionState.clear();
+  applyFilters();
+  setupSearch();
+}
+
+function attemptFallbackData() {
+  const fallback =
+    window.greekPracticeData ||
+    window.practiceData ||
+    window.__PRACTICE_DATA__;
+
+  if (!fallback) {
+    return false;
+  }
+
+  try {
+    handlePracticeData(fallback);
+    return true;
+  } catch (error) {
+    console.error('Failed to parse fallback practice data', error);
+    return false;
+  }
+}
+
+function showLoadError(message) {
+  if (supportMessage) {
+    const prefix = !ttsSupported ? `${ttsNotice} ` : '';
+    supportMessage.textContent = `${prefix}${message}`;
+  }
+  if (resultsMessage) {
+    resultsMessage.textContent = '';
+  }
+  if (groupsContainer) {
+    groupsContainer.textContent = '';
+    const errorMessage = document.createElement('p');
+    errorMessage.className = 'empty-state';
+    errorMessage.textContent = 'We were not able to load any phrases.';
+    groupsContainer.append(errorMessage);
+  }
+}
+
+function loadPracticeData() {
+  fetch('phrases.json', { cache: 'no-store' })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(handlePracticeData)
+    .catch(error => {
+      console.error('Failed to load practice data', error);
+      if (!attemptFallbackData()) {
+        showLoadError('Unable to load the practice list. Please try again later.');
+      }
+    });
+}
 
 if (ttsSupported) {
   window.speechSynthesis.addEventListener('voiceschanged', () => {
@@ -263,3 +673,5 @@ if (ttsSupported) {
   });
   selectedVoice = chooseVoice();
 }
+
+loadPracticeData();

--- a/style.css
+++ b/style.css
@@ -1,8 +1,23 @@
 :root {
   color-scheme: light dark;
-  font-family: 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
   background-color: #eef2f8;
   color: #1f2933;
+  --color-background: #eef2f8;
+  --color-surface: rgba(255, 255, 255, 0.92);
+  --color-surface-strong: #ffffff;
+  --color-border: rgba(15, 23, 42, 0.1);
+  --color-border-strong: rgba(15, 23, 42, 0.18);
+  --color-text: #1f2933;
+  --color-muted: #52606d;
+  --color-muted-strong: #2f3e4e;
+  --color-accent: #2563eb;
+  --color-accent-strong: #1d4ed8;
+  --color-error: #b5474d;
+  --shadow-small: 0 10px 22px rgba(15, 23, 42, 0.08);
+  --shadow-medium: 0 18px 36px rgba(15, 23, 42, 0.1);
+  --shadow-large: 0 26px 48px rgba(15, 23, 42, 0.12);
 }
 
 * {
@@ -14,175 +29,369 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  padding: clamp(1rem, 5vw, 2.75rem) clamp(1.1rem, 5vw, 2.75rem)
-    clamp(3rem, 7vw, 4.25rem);
-  background-color: inherit;
+  padding: clamp(1.5rem, 4vw, 3.2rem) clamp(1rem, 4vw, 2.75rem);
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
-main {
-  width: 100%;
-  max-width: 960px;
+main.page {
+  width: min(960px, 100%);
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 2.2vw, 2.25rem);
+  gap: clamp(1.5rem, 3vw, 2.75rem);
 }
 
-h1 {
-  text-align: center;
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+svg {
+  display: block;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+}
+
+.page-hero {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.16));
+  border-radius: clamp(1.6rem, 4vw, 2.5rem);
+  padding: clamp(1.8rem, 3.6vw, 3rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-large);
+  overflow: hidden;
+}
+
+.page-hero__content {
+  display: grid;
+  gap: clamp(0.6rem, 1.5vw, 1.2rem);
+  max-width: 48rem;
+}
+
+.page-hero__eyebrow {
   margin: 0;
-  font-size: clamp(1.9rem, 2.6vw + 1.6rem, 3rem);
+  font-size: clamp(0.72rem, 1vw, 0.85rem);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 700;
+  color: rgba(37, 99, 235, 0.85);
 }
 
-.description {
-  text-align: center;
-  margin: 0 auto;
-  max-width: 38rem;
-  line-height: 1.6;
-  color: #52606d;
+.page-hero__title {
+  margin: 0;
+  font-size: clamp(2rem, 2.4vw + 1.8rem, 3.2rem);
+}
+
+.page-hero__description {
+  margin: 0;
+  max-width: 44rem;
+  color: var(--color-muted);
+  font-size: clamp(1rem, 1.2vw + 0.9rem, 1.25rem);
+}
+
+.page-controls {
+  background: var(--color-surface);
+  border-radius: clamp(1.4rem, 3vw, 2.2rem);
+  padding: clamp(1.3rem, 2.6vw, 1.8rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-medium);
+  display: grid;
+  gap: clamp(1rem, 2.2vw, 1.5rem);
+}
+
+.page-controls__search {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.field-label {
+  margin: 0;
+  font-size: clamp(0.82rem, 1vw, 0.95rem);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.search-field {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.7rem;
+  align-items: center;
+  border-radius: 16px;
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  padding: 0 clamp(0.75rem, 1.5vw, 1rem);
+  min-height: 3.25rem;
+}
+
+.search-field__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-muted);
+}
+
+.search-field__icon svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: currentColor;
+}
+
+.search-field__input {
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-width: 0;
+  font: inherit;
+  color: inherit;
+}
+
+.search-field__input:focus {
+  outline: none;
+}
+
+.search-field__input::placeholder {
+  color: var(--color-muted);
+  opacity: 0.85;
+}
+
+.search-field__clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-accent);
+  font-weight: 600;
+  border-radius: 12px;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.14s ease, transform 0.14s ease;
+}
+
+.search-field__clear:hover {
+  background: rgba(37, 99, 235, 0.2);
+  transform: translateY(-1px);
+}
+
+.search-field__clear:active {
+  transform: translateY(0);
+}
+
+.search-field__clear:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.search-field__clear[hidden] {
+  display: none;
+}
+
+.search-field__clear-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.search-field__clear-text {
+  display: none;
+}
+
+.status-messages {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.status-message {
+  margin: 0;
+  min-height: 1.3rem;
+  font-size: clamp(0.88rem, 0.9vw, 1rem);
+  color: var(--color-muted);
 }
 
 .support-message {
-  text-align: center;
-  margin: 0.75rem auto 0;
-  color: #b44d4d;
-  min-height: 1.4rem;
+  color: var(--color-error);
 }
 
 .practice-groups {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.75rem, 3vw, 2.75rem);
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.5rem);
 }
 
 .practice-section {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 26px;
-  padding: clamp(1.25rem, 2.6vw, 1.9rem) clamp(1.5rem, 3vw, 2.4rem);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.2rem, 2vw, 1.75rem);
-}
-
-.practice-section-header {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.6rem, 1.4vw, 0.9rem);
-}
-
-.practice-section-title {
-  margin: 0;
-  font-size: clamp(1.55rem, 2vw + 1.35rem, 2.1rem);
-  line-height: 1.2;
-}
-
-.practice-section-description {
-  margin: 0;
-  color: #52606d;
-  line-height: 1.6;
-  max-width: 42rem;
-}
-
-.practice-rows {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1rem, 2.2vw, 1.4rem);
-}
-
-.practice-row {
+  background: var(--color-surface);
+  border-radius: clamp(1.2rem, 2.8vw, 2rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-medium);
+  padding: clamp(1.3rem, 2.8vw, 2rem);
   display: grid;
-  gap: clamp(1rem, 2vw, 1.6rem);
-  padding: clamp(1.1rem, 2.2vw, 1.6rem);
-  background: rgba(241, 245, 249, 0.65);
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  gap: clamp(1.1rem, 2.4vw, 1.6rem);
 }
 
-.practice-row-main {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.65rem, 1.8vw, 1rem);
+.practice-section__header {
+  display: contents;
 }
 
-.practice-row-title {
-  margin: 0;
-  font-size: clamp(1.25rem, 1.7vw + 1rem, 1.7rem);
-  line-height: 1.3;
-}
-
-.practice-row-summary {
-  margin: 0;
-  color: #52606d;
-  line-height: 1.6;
-}
-
-.practice-row-label {
-  margin: 0;
-  font-size: clamp(0.75rem, 1.2vw, 0.85rem);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #64748b;
-}
-
-.practice-row-variants {
+.practice-section__toggle {
   display: grid;
-  gap: clamp(0.55rem, 1.5vw, 0.9rem);
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.4rem);
+  border: none;
+  background: none;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
 }
 
-.practice-row-examples {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.65rem, 1.7vw, 0.9rem);
+.practice-section__toggle:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 4px;
 }
 
-.practice-row-examples-heading {
+.practice-section__text {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.practice-section__title {
   margin: 0;
-  font-size: clamp(1.05rem, 1.4vw, 1.2rem);
-  color: #2f4858;
-  font-weight: 600;
+  font-size: clamp(1.4rem, 1.8vw + 1.1rem, 2rem);
 }
 
-.example-list {
+.practice-section__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: clamp(0.95rem, 0.9vw, 1.05rem);
+}
+
+.practice-section__icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  color: var(--color-accent);
+  transition: transform 0.2s ease;
+}
+
+.practice-section__toggle[aria-expanded='false'] .practice-section__icon {
+  transform: rotate(-90deg);
+}
+
+.practice-section__panel {
+  display: grid;
+  gap: clamp(1.1rem, 2.4vw, 1.6rem);
+}
+
+.practice-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: clamp(0.7rem, 1.8vw, 1rem);
+  gap: clamp(1rem, 2.2vw, 1.5rem);
+}
+
+.practice-card {
+  background: var(--color-surface-strong);
+  border-radius: clamp(1rem, 2.6vw, 1.6rem);
+  border: 1px solid var(--color-border-strong);
+  padding: clamp(1.15rem, 2.2vw, 1.8rem);
+  display: grid;
+  gap: clamp(0.85rem, 2vw, 1.2rem);
+  box-shadow: var(--shadow-small);
+}
+
+.practice-card__meta {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.practice-card__title {
+  margin: 0;
+  font-size: clamp(1.3rem, 1.7vw + 1rem, 1.85rem);
+}
+
+.practice-card__summary {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.practice-card__sections {
+  display: grid;
+  gap: clamp(0.9rem, 2vw, 1.3rem);
+}
+
+.practice-card__group {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.practice-card__label {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.9vw, 0.9rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
+}
+
+.practice-card__heading {
+  margin: 0;
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  font-weight: 650;
+  color: var(--color-muted-strong);
+}
+
+.practice-card__variants {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(0.6rem, 1.6vw, 1rem);
+}
+
+.practice-card__examples {
+  display: grid;
+  gap: clamp(0.6rem, 1.6vw, 1rem);
+}
+
+.practice-card__example-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: clamp(0.6rem, 1.6vw, 1rem);
 }
 
 .speech-button {
   width: 100%;
-  border: none;
+  border: 1px solid var(--color-border-strong);
   border-radius: 16px;
-  padding: clamp(0.85rem, 2.4vw, 1.15rem) clamp(1rem, 2.8vw, 1.4rem);
-  background: #ffffff;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  padding: clamp(0.85rem, 2.2vw, 1.1rem) clamp(1rem, 2.5vw, 1.35rem);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-small);
   text-align: left;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: clamp(0.25rem, 1.6vw, 0.4rem);
+  gap: 0.35rem;
   cursor: pointer;
-  font: inherit;
-  color: inherit;
   transition: transform 0.12s ease, box-shadow 0.12s ease;
 }
 
 .speech-button--compact {
-  padding: clamp(0.65rem, 2vw, 0.85rem) clamp(0.85rem, 2.5vw, 1.1rem);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
-}
-
-.speech-button:focus-visible {
-  outline: 3px solid #2563eb;
-  outline-offset: 3px;
+  padding: clamp(0.7rem, 1.8vw, 0.95rem) clamp(0.85rem, 2.2vw, 1.1rem);
 }
 
 .speech-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+}
+
+.speech-button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 3px;
 }
 
 .speech-button:active {
@@ -193,116 +402,145 @@ h1 {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
 }
 
+.speech-button--disabled,
+.speech-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.speech-button--disabled:hover,
+.speech-button:disabled:hover {
+  transform: none;
+}
+
 .speech-button__text {
-  font-size: clamp(1.15rem, 2.4vw, 1.35rem);
-  font-weight: 600;
+  font-size: clamp(1.1rem, 2.2vw, 1.3rem);
+  font-weight: 650;
 }
 
 .speech-button__pronunciation {
-  font-size: clamp(0.92rem, 1.8vw, 1.05rem);
-  color: #52606d;
+  font-size: clamp(0.92rem, 1.4vw, 1.05rem);
+  color: var(--color-muted);
 }
 
 .speech-button__english {
-  font-size: clamp(0.85rem, 1.6vw, 0.95rem);
-  color: #7b8794;
+  font-size: clamp(0.85rem, 1.2vw, 0.95rem);
+  color: var(--color-muted);
 }
 
 .empty-state {
-  margin: 0 auto;
+  margin: 0;
+  padding: clamp(1.4rem, 2.6vw, 1.8rem);
   text-align: center;
-  color: #52606d;
+  color: var(--color-muted);
+  border: 1px dashed var(--color-border);
+  border-radius: clamp(1.1rem, 2.6vw, 1.5rem);
+  background: var(--color-surface);
 }
 
-@media (min-width: 800px) {
-  .practice-row {
-    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
-    align-items: start;
-  }
-
-  .example-list {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+@media (min-width: 520px) {
+  .search-field__clear-text {
+    display: inline;
   }
 }
 
-@media (max-width: 600px) {
-  .practice-section {
-    border-radius: 20px;
+@media (min-width: 720px) {
+  .page-controls {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
+    align-items: end;
   }
 
-  .practice-row {
-    border-radius: 16px;
+  .status-messages {
+    justify-items: end;
+  }
+
+  .status-message {
+    text-align: right;
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    background-color: #0f172a;
-    color: #e2e8f0;
+    --color-background: #0f172a;
+    --color-surface: rgba(15, 23, 42, 0.88);
+    --color-surface-strong: rgba(30, 41, 59, 0.92);
+    --color-border: rgba(148, 163, 184, 0.18);
+    --color-border-strong: rgba(148, 163, 184, 0.28);
+    --color-text: #e2e8f0;
+    --color-muted: #94a3b8;
+    --color-muted-strong: #cbd5f5;
+    --color-accent: #60a5fa;
+    --color-accent-strong: #3b82f6;
+    --color-error: #f87171;
+    --shadow-small: 0 12px 30px rgba(2, 6, 23, 0.55);
+    --shadow-medium: 0 24px 44px rgba(2, 6, 23, 0.62);
+    --shadow-large: 0 28px 48px rgba(2, 6, 23, 0.7);
+    background-color: var(--color-background);
+    color: var(--color-text);
   }
 
   body {
-    background-color: inherit;
+    background-color: var(--color-background);
   }
 
-  .description {
-    color: #94a3b8;
+  .page-hero {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(56, 189, 248, 0.18));
+    border-color: rgba(148, 163, 184, 0.22);
   }
 
-  .support-message {
-    color: #f87171;
+  .page-hero__eyebrow {
+    color: rgba(148, 163, 184, 0.9);
+  }
+
+  .page-controls {
+    background: var(--color-surface);
+    border-color: rgba(148, 163, 184, 0.22);
+  }
+
+  .search-field {
+    background: rgba(30, 41, 59, 0.92);
+    border-color: rgba(148, 163, 184, 0.32);
+    box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.6);
+  }
+
+  .search-field__clear {
+    background: rgba(59, 130, 246, 0.22);
+    color: #e0f2fe;
+  }
+
+  .search-field__clear:hover {
+    background: rgba(59, 130, 246, 0.32);
   }
 
   .practice-section {
-    background: rgba(15, 23, 42, 0.82);
-    border: 1px solid rgba(148, 163, 184, 0.16);
-    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+    background: rgba(15, 23, 42, 0.88);
+    border-color: rgba(148, 163, 184, 0.22);
   }
 
-  .practice-section-description {
-    color: #94a3b8;
-  }
-
-  .practice-row {
-    background: rgba(30, 41, 59, 0.72);
-    border: 1px solid rgba(148, 163, 184, 0.18);
-  }
-
-  .practice-row-summary {
-    color: #cbd5f5;
-  }
-
-  .practice-row-label {
-    color: #a5b4fc;
-  }
-
-  .practice-row-examples-heading {
-    color: #bfdbfe;
+  .practice-card {
+    background: rgba(30, 41, 59, 0.92);
+    border-color: rgba(148, 163, 184, 0.28);
   }
 
   .speech-button {
-    background: #1e293b;
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
-  }
-
-  .speech-button--compact {
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+    background: rgba(15, 23, 42, 0.86);
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: var(--shadow-small);
   }
 
   .speech-button:hover {
-    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.55);
+    box-shadow: 0 22px 36px rgba(2, 6, 23, 0.6);
   }
 
-  .speech-button__pronunciation {
+  .speech-button__pronunciation,
+  .speech-button__english {
     color: #cbd5f5;
   }
 
-  .speech-button__english {
-    color: #94a3b8;
-  }
-
   .empty-state {
-    color: #94a3b8;
+    background: rgba(30, 41, 59, 0.92);
+    border-color: rgba(148, 163, 184, 0.28);
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the landing layout with a hero, search controls, and live status messaging
- rebuild the styling to deliver accessible, responsive phrase cards with dark mode support
- rework the script to normalize data, add instant search filtering, and collapse/expand sections while improving speech fallbacks

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d05f230a3c832c8348a7b6ba684dc3