### PR TITLE
Condense layout and add desktop two-pane view

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,16 +29,20 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  padding: clamp(1.5rem, 4vw, 3.2rem) clamp(1rem, 4vw, 2.75rem);
+  padding: clamp(1rem, 3vw, 2.25rem) clamp(0.85rem, 3vw, 2rem);
   background-color: var(--color-background);
   color: var(--color-text);
 }
 
 main.page {
-  width: min(960px, 100%);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.75rem);
+  width: min(1280px, 100%);
+  display: grid;
+  gap: clamp(1.1rem, 2.4vw, 1.8rem);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'hero'
+    'controls'
+    'practice';
 }
 
 h1,
@@ -59,9 +63,10 @@ button {
 }
 
 .page-hero {
+  grid-area: hero;
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.16));
-  border-radius: clamp(1.6rem, 4vw, 2.5rem);
-  padding: clamp(1.8rem, 3.6vw, 3rem);
+  border-radius: clamp(0.95rem, 2.4vw, 1.6rem);
+  padding: clamp(1.1rem, 2.4vw, 1.85rem);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-large);
   overflow: hidden;
@@ -69,7 +74,7 @@ button {
 
 .page-hero__content {
   display: grid;
-  gap: clamp(0.6rem, 1.5vw, 1.2rem);
+  gap: clamp(0.45rem, 1vw, 0.85rem);
   max-width: 48rem;
 }
 
@@ -95,18 +100,19 @@ button {
 }
 
 .page-controls {
+  grid-area: controls;
   background: var(--color-surface);
-  border-radius: clamp(1.4rem, 3vw, 2.2rem);
-  padding: clamp(1.3rem, 2.6vw, 1.8rem);
+  border-radius: clamp(0.85rem, 2.2vw, 1.3rem);
+  padding: clamp(0.9rem, 1.8vw, 1.4rem);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-medium);
   display: grid;
-  gap: clamp(1rem, 2.2vw, 1.5rem);
+  gap: clamp(0.75rem, 1.6vw, 1.15rem);
 }
 
 .page-controls__search {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
 
 .field-label {
@@ -121,14 +127,14 @@ button {
 .search-field {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.7rem;
+  gap: 0.55rem;
   align-items: center;
-  border-radius: 16px;
+  border-radius: 14px;
   background: var(--color-surface-strong);
   border: 1px solid var(--color-border-strong);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-  padding: 0 clamp(0.75rem, 1.5vw, 1rem);
-  min-height: 3.25rem;
+  padding: 0 clamp(0.6rem, 1.2vw, 0.85rem);
+  min-height: 2.75rem;
 }
 
 .search-field__icon {
@@ -170,8 +176,8 @@ button {
   background: rgba(37, 99, 235, 0.12);
   color: var(--color-accent);
   font-weight: 600;
-  border-radius: 12px;
-  padding: 0.45rem 0.75rem;
+  border-radius: 10px;
+  padding: 0.35rem 0.6rem;
   cursor: pointer;
   transition: background-color 0.14s ease, transform 0.14s ease;
 }
@@ -205,7 +211,7 @@ button {
 
 .status-messages {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.3rem;
 }
 
 .status-message {
@@ -220,18 +226,19 @@ button {
 }
 
 .practice-groups {
+  grid-area: practice;
   display: grid;
-  gap: clamp(1.6rem, 3vw, 2.5rem);
+  gap: clamp(1rem, 2.4vw, 1.6rem);
 }
 
 .practice-section {
   background: var(--color-surface);
-  border-radius: clamp(1.2rem, 2.8vw, 2rem);
+  border-radius: clamp(0.85rem, 2vw, 1.3rem);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-medium);
-  padding: clamp(1.3rem, 2.8vw, 2rem);
+  padding: clamp(0.95rem, 2vw, 1.4rem);
   display: grid;
-  gap: clamp(1.1rem, 2.4vw, 1.6rem);
+  gap: clamp(0.85rem, 1.8vw, 1.2rem);
 }
 
 .practice-section__header {
@@ -242,7 +249,7 @@ button {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: clamp(0.75rem, 2vw, 1.4rem);
+  gap: clamp(0.6rem, 1.5vw, 1rem);
   border: none;
   background: none;
   text-align: left;
@@ -284,7 +291,7 @@ button {
 
 .practice-section__panel {
   display: grid;
-  gap: clamp(1.1rem, 2.4vw, 1.6rem);
+  gap: clamp(0.85rem, 1.8vw, 1.2rem);
 }
 
 .practice-list {
@@ -292,22 +299,25 @@ button {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: clamp(1rem, 2.2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+  gap: clamp(0.85rem, 1.8vw, 1.2rem);
 }
 
 .practice-card {
   background: var(--color-surface-strong);
-  border-radius: clamp(1rem, 2.6vw, 1.6rem);
+  border-radius: clamp(0.75rem, 1.8vw, 1.2rem);
   border: 1px solid var(--color-border-strong);
-  padding: clamp(1.15rem, 2.2vw, 1.8rem);
+  padding: clamp(0.75rem, 1.6vw, 1.15rem);
   display: grid;
-  gap: clamp(0.85rem, 2vw, 1.2rem);
+  gap: clamp(0.6rem, 1.4vw, 0.9rem);
   box-shadow: var(--shadow-small);
+  height: 100%;
 }
 
 .practice-card__meta {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .practice-card__title {
@@ -322,12 +332,12 @@ button {
 
 .practice-card__sections {
   display: grid;
-  gap: clamp(0.9rem, 2vw, 1.3rem);
+  gap: clamp(0.65rem, 1.4vw, 0.95rem);
 }
 
 .practice-card__group {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.45rem;
 }
 
 .practice-card__label {
@@ -348,13 +358,13 @@ button {
 
 .practice-card__variants {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: clamp(0.6rem, 1.6vw, 1rem);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: clamp(0.45rem, 1.2vw, 0.75rem);
 }
 
 .practice-card__examples {
   display: grid;
-  gap: clamp(0.6rem, 1.6vw, 1rem);
+  gap: clamp(0.5rem, 1.2vw, 0.8rem);
 }
 
 .practice-card__example-list {
@@ -362,26 +372,33 @@ button {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: clamp(0.6rem, 1.6vw, 1rem);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  align-items: stretch;
+  gap: clamp(0.45rem, 1.2vw, 0.75rem);
+}
+
+.practice-card__example-list li {
+  display: contents;
 }
 
 .speech-button {
   width: 100%;
   border: 1px solid var(--color-border-strong);
-  border-radius: 16px;
-  padding: clamp(0.85rem, 2.2vw, 1.1rem) clamp(1rem, 2.5vw, 1.35rem);
+  border-radius: 14px;
+  padding: clamp(0.65rem, 1.6vw, 0.95rem) clamp(0.85rem, 2vw, 1.1rem);
   background: var(--color-surface-strong);
   box-shadow: var(--shadow-small);
   text-align: left;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 0.35rem;
+  align-content: start;
+  gap: 0.25rem;
   cursor: pointer;
   transition: transform 0.12s ease, box-shadow 0.12s ease;
 }
 
 .speech-button--compact {
-  padding: clamp(0.7rem, 1.8vw, 0.95rem) clamp(0.85rem, 2.2vw, 1.1rem);
+  padding: clamp(0.55rem, 1.4vw, 0.85rem) clamp(0.75rem, 1.8vw, 1rem);
 }
 
 .speech-button:hover {
@@ -415,28 +432,110 @@ button {
 }
 
 .speech-button__text {
-  font-size: clamp(1.1rem, 2.2vw, 1.3rem);
+  font-size: clamp(1rem, 1.8vw, 1.2rem);
   font-weight: 650;
 }
 
 .speech-button__pronunciation {
-  font-size: clamp(0.92rem, 1.4vw, 1.05rem);
+  font-size: clamp(0.85rem, 1.2vw, 0.98rem);
   color: var(--color-muted);
 }
 
 .speech-button__english {
-  font-size: clamp(0.85rem, 1.2vw, 0.95rem);
+  font-size: clamp(0.78rem, 1vw, 0.9rem);
   color: var(--color-muted);
 }
 
 .empty-state {
   margin: 0;
-  padding: clamp(1.4rem, 2.6vw, 1.8rem);
+  padding: clamp(1rem, 2vw, 1.4rem);
   text-align: center;
   color: var(--color-muted);
   border: 1px dashed var(--color-border);
-  border-radius: clamp(1.1rem, 2.6vw, 1.5rem);
+  border-radius: clamp(0.85rem, 2vw, 1.2rem);
   background: var(--color-surface);
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 0.85rem 0.75rem;
+  }
+
+  main.page {
+    gap: 0.9rem;
+  }
+
+  .page-hero {
+    border-radius: 0.9rem;
+    padding: 0.95rem 0.9rem;
+  }
+
+  .page-hero__content {
+    gap: 0.4rem;
+  }
+
+  .page-controls {
+    border-radius: 0.8rem;
+    padding: 0.8rem 0.85rem;
+    gap: 0.65rem;
+  }
+
+  .page-controls__search {
+    gap: 0.4rem;
+  }
+
+  .search-field {
+    border-radius: 12px;
+    padding: 0 0.55rem;
+    min-height: 2.55rem;
+  }
+
+  .search-field__clear {
+    padding: 0.28rem 0.45rem;
+  }
+
+  .practice-groups {
+    gap: 0.9rem;
+  }
+
+  .practice-section {
+    border-radius: 0.8rem;
+    padding: 0.85rem 0.85rem;
+    gap: 0.75rem;
+  }
+
+  .practice-section__toggle {
+    gap: 0.55rem;
+  }
+
+  .practice-card {
+    border-radius: 0.7rem;
+    padding: 0.65rem 0.7rem;
+    gap: 0.55rem;
+  }
+
+  .practice-card__sections {
+    gap: 0.55rem;
+  }
+
+  .practice-card__group {
+    gap: 0.4rem;
+  }
+
+  .practice-card__variants,
+  .practice-card__examples,
+  .practice-card__example-list {
+    gap: 0.45rem;
+  }
+
+  .speech-button {
+    padding: 0.55rem 0.75rem;
+    gap: 0.2rem;
+  }
+
+  .speech-button--compact {
+    padding: 0.45rem 0.6rem;
+  }
 }
 
 @media (min-width: 520px) {
@@ -457,6 +556,26 @@ button {
 
   .status-message {
     text-align: right;
+  }
+}
+
+@media (min-width: 1024px) {
+  main.page {
+    grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
+    grid-template-areas:
+      'hero practice'
+      'controls practice';
+    align-items: start;
+    gap: 1.25rem;
+  }
+
+  .page-hero,
+  .page-controls {
+    align-self: start;
+  }
+
+  .practice-groups {
+    align-self: stretch;
   }
 }
 


### PR DESCRIPTION
## Summary
- convert the page layout to a responsive CSS grid with a two-pane desktop arrangement so the practice list uses the extra width
- tighten padding and gaps across the hero, controls, practice sections, and cards to keep the experience compact on every screen size
- render example phrases as mini cards with condensed speech buttons to reduce vertical sprawl

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d06490d03c832ca01f3e2677fa1348