### PR TITLE
Refine layout and collapse example phrases

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,8 @@
           Practice the phrases you already know, listen to the pronunciation, and see them used inside short, practical sentences.
         </p>
       </div>
-    </header>
 
-    <section class="page-controls" aria-label="Practice controls">
-      <div class="page-controls__search">
+      <div class="page-hero__search" role="search">
         <label class="field-label" for="phrase-search">Search phrases</label>
         <div class="search-field">
           <span class="search-field__icon" aria-hidden="true">
@@ -45,7 +43,9 @@
           </button>
         </div>
       </div>
+    </header>
 
+    <section class="page-status" aria-label="Practice updates">
       <div class="status-messages">
         <p id="results-message" class="status-message" aria-live="polite"></p>
         <p id="support-message" class="status-message support-message" aria-live="polite"></p>

--- a/index.html
+++ b/index.html
@@ -45,14 +45,14 @@
       </div>
     </header>
 
-    <section class="page-status" aria-label="Practice updates">
+    <section class="practice-area" aria-label="Practice phrases">
       <div class="status-messages">
         <p id="results-message" class="status-message" aria-live="polite"></p>
         <p id="support-message" class="status-message support-message" aria-live="polite"></p>
       </div>
-    </section>
 
-    <div id="practice-groups" class="practice-groups" aria-live="polite"></div>
+      <div id="practice-groups" class="practice-groups" aria-live="polite"></div>
+    </section>
   </main>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -301,11 +301,13 @@ function createSpeechButton(phrase, { compact = false } = {}) {
   return button;
 }
 
-function createChevronIcon() {
+function createChevronIcon(className = 'practice-section__icon') {
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('viewBox', '0 0 16 16');
   svg.setAttribute('aria-hidden', 'true');
-  svg.classList.add('practice-section__icon');
+  if (className) {
+    svg.classList.add(className);
+  }
   const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
   path.setAttribute(
     'd',
@@ -385,13 +387,26 @@ function createPracticeRow(row) {
     const examplesGroup = document.createElement('div');
     examplesGroup.className = 'practice-card__group practice-card__examples';
 
-    const heading = document.createElement('h4');
-    heading.className = 'practice-card__heading';
-    heading.textContent = row.examplesHeading || 'Example phrases';
-    examplesGroup.append(heading);
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'practice-card__examples-toggle practice-card__label';
+    toggle.setAttribute('aria-expanded', 'false');
+
+    const toggleText = document.createElement('span');
+    toggleText.className = 'practice-card__examples-text';
+    toggleText.textContent = row.examplesHeading || 'Example phrases';
+    toggle.append(toggleText);
+
+    const toggleIcon = createChevronIcon('practice-card__examples-icon');
+    toggle.append(toggleIcon);
 
     const list = document.createElement('ul');
     list.className = 'practice-card__example-list';
+    const listId = `${row.__id || 'row'}-examples`;
+    list.id = listId;
+    list.hidden = true;
+    list.setAttribute('aria-hidden', 'true');
+    toggle.setAttribute('aria-controls', listId);
 
     examples.forEach(example => {
       const button = createSpeechButton(example);
@@ -403,8 +418,17 @@ function createPracticeRow(row) {
     });
 
     if (list.children.length) {
+      examplesGroup.append(toggle);
       examplesGroup.append(list);
       sectionsWrapper.append(examplesGroup);
+
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        const next = !expanded;
+        toggle.setAttribute('aria-expanded', String(next));
+        list.hidden = !next;
+        list.setAttribute('aria-hidden', String(!next));
+      });
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -41,8 +41,14 @@ main.page {
   grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     'hero'
-    'status'
     'practice';
+}
+
+.practice-area {
+  grid-area: practice;
+  display: grid;
+  gap: clamp(0.7rem, 1.6vw, 1.1rem);
+  align-content: start;
 }
 
 h1,
@@ -115,15 +121,6 @@ button {
   max-width: 44rem;
   color: var(--color-muted);
   font-size: clamp(0.95rem, 1vw + 0.85rem, 1.18rem);
-}
-
-.page-status {
-  grid-area: status;
-  background: var(--color-surface);
-  border-radius: clamp(0.85rem, 2vw, 1.25rem);
-  padding: clamp(0.65rem, 1.4vw, 1rem);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-medium);
 }
 
 .field-label {
@@ -221,15 +218,22 @@ button {
 }
 
 .status-messages {
-  display: grid;
-  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .status-message {
   margin: 0;
-  min-height: 1.1rem;
   font-size: clamp(0.84rem, 0.85vw, 0.95rem);
   color: var(--color-muted);
+}
+
+.status-message:empty {
+  display: none;
 }
 
 .support-message {
@@ -237,7 +241,6 @@ button {
 }
 
 .practice-groups {
-  grid-area: practice;
   display: grid;
   gap: clamp(0.85rem, 1.8vw, 1.25rem);
 }
@@ -547,11 +550,6 @@ button {
     width: 100%;
   }
 
-  .page-status {
-    border-radius: 0.7rem;
-    padding: 0.6rem 0.7rem;
-  }
-
   .search-field {
     border-radius: 10px;
     padding: 0 0.45rem;
@@ -629,10 +627,14 @@ button {
   }
 
   .status-messages {
-    justify-items: end;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: clamp(0.35rem, 1vw, 0.6rem);
   }
 
-  .status-message {
+  .support-message:not(:empty) {
+    margin-left: auto;
     text-align: right;
   }
 }
@@ -661,7 +663,7 @@ button {
     grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
     grid-template-areas:
       'hero hero'
-      'status practice';
+      'practice practice';
     align-items: start;
     gap: 1rem;
   }
@@ -670,11 +672,7 @@ button {
     grid-column: 1 / -1;
   }
 
-  .page-status {
-    align-self: start;
-  }
-
-  .practice-groups {
+  .practice-area {
     align-self: stretch;
   }
 }
@@ -722,11 +720,6 @@ button {
   .page-hero__search {
     background: rgba(30, 41, 59, 0.92);
     border-color: rgba(148, 163, 184, 0.28);
-  }
-
-  .page-status {
-    background: var(--color-surface);
-    border-color: rgba(148, 163, 184, 0.22);
   }
 
   .search-field {

--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ main.page {
   grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     'hero'
-    'controls'
+    'status'
     'practice';
 }
 
@@ -70,12 +70,30 @@ button {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-large);
   overflow: hidden;
+  display: grid;
+  gap: clamp(0.85rem, 1.8vw, 1.3rem);
 }
 
 .page-hero__content {
   display: grid;
   gap: clamp(0.35rem, 0.9vw, 0.7rem);
   max-width: 48rem;
+}
+
+.page-hero__search {
+  display: grid;
+  gap: 0.4rem;
+  align-content: start;
+  padding: clamp(0.6rem, 1vw, 0.85rem) clamp(0.7rem, 1.4vw, 1rem);
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: clamp(0.85rem, 1.8vw, 1.2rem);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-small);
+  width: min(100%, 420px);
+}
+
+.page-hero__search .field-label {
+  color: var(--color-muted-strong);
 }
 
 .page-hero__eyebrow {
@@ -99,20 +117,13 @@ button {
   font-size: clamp(0.95rem, 1vw + 0.85rem, 1.18rem);
 }
 
-.page-controls {
-  grid-area: controls;
+.page-status {
+  grid-area: status;
   background: var(--color-surface);
-  border-radius: clamp(0.85rem, 2.2vw, 1.3rem);
-  padding: clamp(0.75rem, 1.6vw, 1.2rem);
+  border-radius: clamp(0.85rem, 2vw, 1.25rem);
+  padding: clamp(0.65rem, 1.4vw, 1rem);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-medium);
-  display: grid;
-  gap: clamp(0.6rem, 1.4vw, 0.95rem);
-}
-
-.page-controls__search {
-  display: grid;
-  gap: 0.4rem;
 }
 
 .field-label {
@@ -348,6 +359,48 @@ button {
   gap: 0.35rem;
 }
 
+.practice-card__examples-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.practice-card__examples-toggle:hover {
+  color: var(--color-muted-strong);
+}
+
+.practice-card__examples-toggle:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 3px;
+}
+
+.practice-card__examples-text {
+  flex: 1;
+}
+
+.practice-card__examples-icon {
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-accent);
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.practice-card__examples-toggle:hover .practice-card__examples-icon {
+  color: var(--color-accent-strong);
+}
+
+.practice-card__examples-toggle[aria-expanded='false'] .practice-card__examples-icon {
+  transform: rotate(-90deg);
+}
+
 .practice-card__label {
   margin: 0;
   font-size: clamp(0.72rem, 0.85vw, 0.85rem);
@@ -481,20 +534,22 @@ button {
   .page-hero {
     border-radius: 0.75rem;
     padding: 0.75rem 0.7rem;
+    gap: 0.7rem;
   }
 
   .page-hero__content {
     gap: 0.32rem;
   }
 
-  .page-controls {
+  .page-hero__search {
+    padding: 0.55rem 0.6rem;
     border-radius: 0.7rem;
-    padding: 0.65rem 0.7rem;
-    gap: 0.55rem;
+    width: 100%;
   }
 
-  .page-controls__search {
-    gap: 0.4rem;
+  .page-status {
+    border-radius: 0.7rem;
+    padding: 0.6rem 0.7rem;
   }
 
   .search-field {
@@ -563,9 +618,14 @@ button {
 }
 
 @media (min-width: 720px) {
-  .page-controls {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
-    align-items: end;
+  .page-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.9fr);
+    align-items: start;
+  }
+
+  .page-hero__search {
+    justify-self: end;
+    align-self: start;
   }
 
   .status-messages {
@@ -601,7 +661,7 @@ button {
     grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
     grid-template-areas:
       'hero hero'
-      'controls practice';
+      'status practice';
     align-items: start;
     gap: 1rem;
   }
@@ -610,7 +670,7 @@ button {
     grid-column: 1 / -1;
   }
 
-  .page-controls {
+  .page-status {
     align-self: start;
   }
 
@@ -659,7 +719,12 @@ button {
     color: rgba(148, 163, 184, 0.9);
   }
 
-  .page-controls {
+  .page-hero__search {
+    background: rgba(30, 41, 59, 0.92);
+    border-color: rgba(148, 163, 184, 0.28);
+  }
+
+  .page-status {
     background: var(--color-surface);
     border-color: rgba(148, 163, 184, 0.22);
   }


### PR DESCRIPTION
## Summary
- move the search controls into the hero header and add a slimmer status container so the practice list gets more room
- update styles for the revised layout and add shared typography plus toggle styling for example phrases
- hide example phrases by default with an accessible toggle and reusable chevron helper

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1034b13fc832ca6f5b9a2807ef85d