### PR TITLE
Fix hidden attribute for collapsible sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,6 +24,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- ensure elements using the `hidden` attribute stay hidden by default
- add a global `[hidden]` rule so collapsible panels and example lists can be toggled correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10786e938832c943ab8838da0d559