### PR TITLE
Add Greek alphabet reference section

### DIFF
--- a/phrases.json
+++ b/phrases.json
@@ -398,5 +398,324 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Greek Alphabet",
+    "description": "Reference each letter with its English pronunciation.",
+    "layout": "alphabet",
+    "rows": [
+      {
+        "title": "Α α",
+        "summary": "Alpha",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Α α",
+            "english": "Alpha",
+            "speech": "άλφα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Β β",
+        "summary": "Beta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Β β",
+            "english": "Beta",
+            "speech": "βήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Γ γ",
+        "summary": "Gamma",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Γ γ",
+            "english": "Gamma",
+            "speech": "γάμμα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Δ δ",
+        "summary": "Delta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Δ δ",
+            "english": "Delta",
+            "speech": "δέλτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ε ε",
+        "summary": "Epsilon",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ε ε",
+            "english": "Epsilon",
+            "speech": "έψιλον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ζ ζ",
+        "summary": "Zeta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ζ ζ",
+            "english": "Zeta",
+            "speech": "ζήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Η η",
+        "summary": "Eta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Η η",
+            "english": "Eta",
+            "speech": "ήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Θ θ",
+        "summary": "Theta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Θ θ",
+            "english": "Theta",
+            "speech": "θήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ι ι",
+        "summary": "Iota",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ι ι",
+            "english": "Iota",
+            "speech": "ιώτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Κ κ",
+        "summary": "Kappa",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Κ κ",
+            "english": "Kappa",
+            "speech": "κάππα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Λ λ",
+        "summary": "Lambda",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Λ λ",
+            "english": "Lambda",
+            "speech": "λάμδα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Μ μ",
+        "summary": "Mu",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Μ μ",
+            "english": "Mu",
+            "speech": "μι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ν ν",
+        "summary": "Nu",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ν ν",
+            "english": "Nu",
+            "speech": "νι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ξ ξ",
+        "summary": "Xi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ξ ξ",
+            "english": "Xi",
+            "speech": "ξι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ο ο",
+        "summary": "Omicron",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ο ο",
+            "english": "Omicron",
+            "speech": "όμικρον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Π π",
+        "summary": "Pi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Π π",
+            "english": "Pi",
+            "speech": "πι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ρ ρ",
+        "summary": "Rho",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ρ ρ",
+            "english": "Rho",
+            "speech": "ρο",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Σ σ / ς",
+        "summary": "Sigma",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Σ σ / ς",
+            "english": "Sigma",
+            "speech": "σίγμα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Τ τ",
+        "summary": "Tau",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Τ τ",
+            "english": "Tau",
+            "speech": "ταυ",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Υ υ",
+        "summary": "Upsilon",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Υ υ",
+            "english": "Upsilon",
+            "speech": "ύψιλον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Φ φ",
+        "summary": "Phi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Φ φ",
+            "english": "Phi",
+            "speech": "φι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Χ χ",
+        "summary": "Chi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Χ χ",
+            "english": "Chi",
+            "speech": "χι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ψ ψ",
+        "summary": "Psi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ψ ψ",
+            "english": "Psi",
+            "speech": "ψι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ω ω",
+        "summary": "Omega",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ω ω",
+            "english": "Omega",
+            "speech": "ωμέγα",
+            "lang": "el-GR"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/style.css
+++ b/style.css
@@ -459,6 +459,36 @@ button {
   flex: 1;
 }
 
+.practice-section--alphabet .practice-section__panel,
+.practice-section__panel--alphabet {
+  gap: clamp(0.55rem, 1.2vw, 0.85rem);
+}
+
+.alphabet-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+  align-items: stretch;
+}
+
+.alphabet-card {
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+  gap: 0.22rem;
+  padding: clamp(0.35rem, 1vw, 0.55rem) clamp(0.4rem, 1vw, 0.65rem);
+  min-height: clamp(2.6rem, 5vw, 3.1rem);
+}
+
+.alphabet-card .speech-button__text {
+  font-size: clamp(1.05rem, 1.8vw, 1.4rem);
+}
+
+.alphabet-card .speech-button__english {
+  font-size: clamp(0.75rem, 0.95vw, 0.9rem);
+}
+
 .speech-button {
   width: 100%;
   border: 1px solid var(--color-border-strong);
@@ -608,6 +638,15 @@ button {
     min-width: 100%;
   }
 
+  .alphabet-grid {
+    gap: 0.35rem;
+  }
+
+  .alphabet-card {
+    padding: 0.28rem 0.4rem;
+    min-height: 2.4rem;
+  }
+
   .speech-button {
     padding: 0.38rem 0.55rem;
     gap: 0.16rem;
@@ -615,6 +654,24 @@ button {
 
   .speech-button--compact {
     padding: 0.3rem 0.45rem;
+  }
+}
+
+@media (min-width: 600px) {
+  .alphabet-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .alphabet-grid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .alphabet-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated Greek alphabet section rendered as a compact responsive grid with speech buttons
- extend the phrase dataset to include every Greek letter with English names and speech metadata

## Testing
- node -e "const fs=require('fs');JSON.parse(fs.readFileSync('phrases.json','utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68d29e501008832caffdbb393c11dbdd