### PR TITLE
Add Greek alphabet section with responsive grid

### DIFF
--- a/phrases.json
+++ b/phrases.json
@@ -398,5 +398,348 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Greek Alphabet",
+    "description": "Review each Greek letter and its English pronunciation.",
+    "layout": "alphabet",
+    "rows": [
+      {
+        "title": "Α α",
+        "summary": "Alpha",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Α α",
+            "pronunciation": "Alpha",
+            "english": "AL-fah",
+            "speech": "άλφα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Β β",
+        "summary": "Beta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Β β",
+            "pronunciation": "Beta",
+            "english": "BAY-tuh",
+            "speech": "βήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Γ γ",
+        "summary": "Gamma",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Γ γ",
+            "pronunciation": "Gamma",
+            "english": "GAM-uh",
+            "speech": "γάμμα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Δ δ",
+        "summary": "Delta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Δ δ",
+            "pronunciation": "Delta",
+            "english": "DEL-tuh",
+            "speech": "δέλτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ε ε",
+        "summary": "Epsilon",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ε ε",
+            "pronunciation": "Epsilon",
+            "english": "EP-sih-lon",
+            "speech": "έψιλον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ζ ζ",
+        "summary": "Zeta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ζ ζ",
+            "pronunciation": "Zeta",
+            "english": "ZAY-tuh",
+            "speech": "ζήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Η η",
+        "summary": "Eta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Η η",
+            "pronunciation": "Eta",
+            "english": "AY-tuh",
+            "speech": "ήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Θ θ",
+        "summary": "Theta",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Θ θ",
+            "pronunciation": "Theta",
+            "english": "THAY-tuh",
+            "speech": "θήτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ι ι",
+        "summary": "Iota",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ι ι",
+            "pronunciation": "Iota",
+            "english": "eye-OH-tuh",
+            "speech": "ιώτα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Κ κ",
+        "summary": "Kappa",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Κ κ",
+            "pronunciation": "Kappa",
+            "english": "KAP-uh",
+            "speech": "κάππα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Λ λ",
+        "summary": "Lambda",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Λ λ",
+            "pronunciation": "Lambda",
+            "english": "LAM-duh",
+            "speech": "λάμδα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Μ μ",
+        "summary": "Mu",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Μ μ",
+            "pronunciation": "Mu",
+            "english": "MYOO",
+            "speech": "μι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ν ν",
+        "summary": "Nu",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ν ν",
+            "pronunciation": "Nu",
+            "english": "NYOO",
+            "speech": "νι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ξ ξ",
+        "summary": "Xi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ξ ξ",
+            "pronunciation": "Xi",
+            "english": "ks-EYE",
+            "speech": "ξι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ο ο",
+        "summary": "Omicron",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ο ο",
+            "pronunciation": "Omicron",
+            "english": "OH-mih-kron",
+            "speech": "όμικρον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Π π",
+        "summary": "Pi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Π π",
+            "pronunciation": "Pi",
+            "english": "PIE",
+            "speech": "πι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ρ ρ",
+        "summary": "Rho",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ρ ρ",
+            "pronunciation": "Rho",
+            "english": "ROH",
+            "speech": "ρο",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Σ σ/ς",
+        "summary": "Sigma",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Σ σ/ς",
+            "pronunciation": "Sigma",
+            "english": "SIG-muh",
+            "speech": "σίγμα",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Τ τ",
+        "summary": "Tau",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Τ τ",
+            "pronunciation": "Tau",
+            "english": "TOW",
+            "speech": "ταυ",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Υ υ",
+        "summary": "Upsilon",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Υ υ",
+            "pronunciation": "Upsilon",
+            "english": "OOP-sih-lon",
+            "speech": "ύψιλον",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Φ φ",
+        "summary": "Phi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Φ φ",
+            "pronunciation": "Phi",
+            "english": "FIE",
+            "speech": "φι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Χ χ",
+        "summary": "Chi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Χ χ",
+            "pronunciation": "Chi",
+            "english": "KAI",
+            "speech": "χι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ψ ψ",
+        "summary": "Psi",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ψ ψ",
+            "pronunciation": "Psi",
+            "english": "PSAI",
+            "speech": "ψι",
+            "lang": "el-GR"
+          }
+        ]
+      },
+      {
+        "title": "Ω ω",
+        "summary": "Omega",
+        "variantsLabel": false,
+        "variants": [
+          {
+            "greek": "Ω ω",
+            "pronunciation": "Omega",
+            "english": "oh-MAY-guh",
+            "speech": "ωμέγα",
+            "lang": "el-GR"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/script.js
+++ b/script.js
@@ -301,6 +301,68 @@ function createSpeechButton(phrase, { compact = false } = {}) {
   return button;
 }
 
+function createAlphabetCard(row) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const variants = Array.isArray(row.variants) ? row.variants : [];
+  if (!variants.length) {
+    return null;
+  }
+
+  const [primaryVariant] = variants;
+  const button = createSpeechButton(
+    {
+      ...primaryVariant,
+      greek:
+        (typeof row.title === 'string' && row.title.trim()) ||
+        primaryVariant.greek ||
+        '',
+    },
+    { compact: true }
+  );
+
+  if (!button) {
+    return null;
+  }
+
+  button.classList.add('alphabet-card__button');
+
+  const labelParts = [
+    typeof row.title === 'string' ? row.title.trim() : '',
+    typeof primaryVariant.pronunciation === 'string'
+      ? primaryVariant.pronunciation.trim()
+      : '',
+    typeof primaryVariant.english === 'string' ? primaryVariant.english.trim() : '',
+  ].filter(Boolean);
+
+  if (labelParts.length) {
+    button.setAttribute('aria-label', labelParts.join(' — '));
+  }
+
+  const greekText = button.querySelector('.speech-button__text');
+  if (greekText) {
+    greekText.classList.add('alphabet-card__greek');
+  }
+
+  const pronunciation = button.querySelector('.speech-button__pronunciation');
+  if (pronunciation) {
+    pronunciation.classList.add('alphabet-card__name');
+  }
+
+  const english = button.querySelector('.speech-button__english');
+  if (english) {
+    english.classList.add('alphabet-card__pronunciation');
+  }
+
+  const item = document.createElement('li');
+  item.className = 'alphabet-card';
+  item.append(button);
+
+  return item;
+}
+
 function createChevronIcon(className = 'practice-section__icon') {
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('viewBox', '0 0 16 16');
@@ -447,6 +509,14 @@ function createPracticeSection(sectionData, { forceExpand = false } = {}) {
   const section = document.createElement('section');
   section.className = 'practice-section';
 
+  const layout =
+    typeof sectionData.layout === 'string' ? sectionData.layout.trim().toLowerCase() : '';
+  const isAlphabet = layout === 'alphabet';
+
+  if (isAlphabet) {
+    section.classList.add('practice-section--alphabet');
+  }
+
   const header = document.createElement('header');
   header.className = 'practice-section__header';
 
@@ -495,9 +565,12 @@ function createPracticeSection(sectionData, { forceExpand = false } = {}) {
   panel.setAttribute('aria-hidden', shouldExpand ? 'false' : 'true');
 
   const list = document.createElement('ul');
-  list.className = 'practice-list';
+  list.className = isAlphabet ? 'alphabet-grid' : 'practice-list';
+
+  const createRowElement = isAlphabet ? createAlphabetCard : createPracticeRow;
+
   sectionData.rows.forEach(row => {
-    const rowElement = createPracticeRow(row);
+    const rowElement = createRowElement(row);
     if (rowElement) {
       list.append(rowElement);
     }

--- a/style.css
+++ b/style.css
@@ -331,6 +331,50 @@ button {
   gap: 0;
 }
 
+.practice-section--alphabet {
+  gap: clamp(0.6rem, 1.2vw, 0.9rem);
+}
+
+.alphabet-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+}
+
+.alphabet-card {
+  margin: 0;
+  display: flex;
+}
+
+.alphabet-card__button {
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+  gap: 0.22rem;
+  padding: clamp(0.35rem, 0.95vw, 0.55rem) clamp(0.45rem, 1vw, 0.65rem);
+  height: 100%;
+}
+
+.alphabet-card__greek {
+  font-size: clamp(1.2rem, 2vw + 0.8rem, 2.1rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.alphabet-card__name {
+  font-size: clamp(0.82rem, 0.9vw, 0.95rem);
+  color: var(--color-muted-strong);
+}
+
+.alphabet-card__pronunciation {
+  font-size: clamp(0.72rem, 0.8vw, 0.85rem);
+  color: var(--color-muted);
+}
+
 .practice-card {
   background: var(--color-surface-strong);
   border-radius: clamp(0.75rem, 1.8vw, 1.2rem);
@@ -618,6 +662,12 @@ button {
   }
 }
 
+@media (min-width: 480px) {
+  .alphabet-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 520px) {
   .search-field__clear-text {
     display: inline;
@@ -628,6 +678,10 @@ button {
   .page-hero {
     grid-template-columns: minmax(0, 1fr) minmax(260px, 0.9fr);
     align-items: start;
+  }
+
+  .alphabet-grid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 
   .page-hero__search {
@@ -675,6 +729,10 @@ button {
       'practice practice';
     align-items: start;
     gap: 1rem;
+  }
+
+  .alphabet-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 
   .page-hero {


### PR DESCRIPTION
## Summary
- add data for a dedicated Greek alphabet section with English pronunciations
- render alphabet rows with compact cards and custom accessibility labelling
- style the alphabet layout as a responsive 4/6/8/12 column grid of letter cards

## Testing
- jq '.' phrases.json

------
https://chatgpt.com/codex/tasks/task_e_68d29e501008832caffdbb393c11dbdd